### PR TITLE
feat(web): add PWA manifest and service worker

### DIFF
--- a/_/apps/web/public/manifest.json
+++ b/_/apps/web/public/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "Asset Management Web",
+  "short_name": "Assets",
+  "id": "/",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/_/apps/web/public/service-worker.js
+++ b/_/apps/web/public/service-worker.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'asset-management-cache-v1';
+const URLS_TO_CACHE = ['/', '/manifest.json'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(cacheNames =>
+      Promise.all(
+        cacheNames
+          .filter(name => name !== CACHE_NAME)
+          .map(name => caches.delete(name))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match('/'));
+    })
+  );
+});

--- a/_/apps/web/src/app/layout.jsx
+++ b/_/apps/web/src/app/layout.jsx
@@ -2,15 +2,26 @@
 "use client"; // <- Penting untuk React Query bekerja
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export const metadata = {
   title: "Generator Set Management System",
   description: "Manage and monitor your generator units",
+  manifest: "/manifest.json",
 };
 
 export default function RootLayout({ children }) {
   const [queryClient] = useState(() => new QueryClient());
+
+  useEffect(() => {
+    if (import.meta.env.PROD && "serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/service-worker.js")
+        .catch((err) => {
+          console.error("Service worker registration failed:", err);
+        });
+    }
+  }, []);
 
   return (
     <>

--- a/_/apps/web/vite.config.ts
+++ b/_/apps/web/vite.config.ts
@@ -14,6 +14,7 @@ import { restart } from './plugins/restart';
 import { restartEnvFileChange } from './plugins/restartEnvFileChange';
 
 export default defineConfig({
+  publicDir: 'public',
   // Keep them available via import.meta.env.NEXT_PUBLIC_*
   envPrefix: 'NEXT_PUBLIC_',
   optimizeDeps: {
@@ -32,6 +33,9 @@ export default defineConfig({
     ],
   },
   logLevel: 'info',
+  build: {
+    copyPublicDir: true,
+  },
   plugins: [
     nextPublicProcessEnv(),
     restartEnvFileChange(),


### PR DESCRIPTION
## Summary
- add PWA manifest and service worker for offline caching
- register service worker and manifest link in root layout
- configure Vite to include public assets in build
- refine caching logic and production-only registration
- remove committed favicon image and reference placeholder icons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68a672556bd4832aba0fc4de530476d9