### PR TITLE
feat: add hook for unit QR code

### DIFF
--- a/_/apps/web/src/components/Unit/UnitQRCodeCard.jsx
+++ b/_/apps/web/src/components/Unit/UnitQRCodeCard.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useUnitQrCode } from "../../hooks/useUnitQrCode";
+import { useUnitQrCode } from "@/hooks/useUnitQrCode";
 import { QrCode, Download } from "lucide-react";
 
 export function UnitQRCodeCard({ unit }) {

--- a/_/apps/web/src/hooks/useUnitQrCode.js
+++ b/_/apps/web/src/hooks/useUnitQrCode.js
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+export function useUnitQrCode(unit) {
+  const [qrCodeUrl, setQrCodeUrl] = useState(null);
+  const [loadingQr, setLoadingQr] = useState(false);
+
+  const generateQrCode = async () => {
+    if (!unit?.id) return;
+
+    try {
+      setLoadingQr(true);
+      const response = await fetch(`/api/units/${unit.id}/qr`);
+      if (!response.ok) {
+        throw new Error("Failed to generate QR code");
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      setQrCodeUrl(url);
+    } catch (error) {
+      console.error("Error generating QR code:", error);
+    } finally {
+      setLoadingQr(false);
+    }
+  };
+
+  const downloadQrCode = () => {
+    if (!qrCodeUrl) return;
+
+    const link = document.createElement("a");
+    link.href = qrCodeUrl;
+    link.download = `unit-${unit?.id}-qr.png`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return { qrCodeUrl, loadingQr, generateQrCode, downloadQrCode };
+}


### PR DESCRIPTION
## Summary
- add reusable useUnitQrCode hook for generating and downloading unit QR codes
- update UnitQRCodeCard to import hook from new location

## Testing
- `npx -y vitest run` *(fails: Cannot find package 'vitest' imported from vitest.config.ts)*
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a69eb9c114832a8874b9faa12d3cae