### PR TITLE
feat: secure QR token generation

### DIFF
--- a/_/apps/web/src/app/api/units/[id]/qr/route.js
+++ b/_/apps/web/src/app/api/units/[id]/qr/route.js
@@ -1,0 +1,55 @@
+import sql from "@/app/api/utils/sql";
+import crypto from "crypto";
+
+// Generate QR code for a unit
+export async function GET(request, { params }) {
+  const { id } = params;
+
+  if (!id) {
+    return Response.json({ error: "Unit ID is required" }, { status: 400 });
+  }
+
+  // Fetch unit details including existing token
+  const units = await sql`
+    SELECT id, serial_number, serial_number_engine, access_token
+    FROM units
+    WHERE id = ${parseInt(id)} AND is_active = true AND deleted_at IS NULL
+  `;
+
+  if (units.length === 0) {
+    return Response.json({ error: "Unit not found" }, { status: 404 });
+  }
+
+  const unit = units[0];
+
+  // Ensure the unit has a token stored
+  let token = unit.access_token;
+  if (!token) {
+    token = crypto.randomUUID();
+    await sql`UPDATE units SET access_token = ${token} WHERE id = ${unit.id}`;
+  }
+
+  // Build the URL that the QR code should encode
+  const baseUrl = new URL(request.url);
+  const origin = `${baseUrl.protocol}//${baseUrl.host}`;
+  const serial = unit.serial_number_engine || unit.serial_number;
+  const qrLink = `${origin}/unit/${serial}?token=${token}`;
+
+  // Use an external service to generate the QR code image
+  const qrResponse = await fetch(
+    `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(
+      qrLink,
+    )}`,
+  );
+
+  if (!qrResponse.ok) {
+    return Response.json({ error: "Failed to generate QR code" }, { status: 500 });
+  }
+
+  const imageBuffer = await qrResponse.arrayBuffer();
+
+  return new Response(imageBuffer, {
+    headers: { "Content-Type": "image/png" },
+  });
+}
+

--- a/_/apps/web/src/app/api/units/route.js
+++ b/_/apps/web/src/app/api/units/route.js
@@ -1,5 +1,6 @@
 import sql from "@/app/api/utils/sql";
 import { auth } from "@/auth";
+import crypto from "crypto";
 
 // Get all units with company info
 export async function GET(request) {
@@ -56,11 +57,8 @@ export async function POST(request) {
 
     const data = await request.json();
 
-    // Generate unique access token
-    const accessToken =
-      "unit_" +
-      Math.random().toString(36).substring(2, 15) +
-      Date.now().toString(36);
+    // Generate unique access token using a secure random UUID
+    const accessToken = crypto.randomUUID();
 
     const result = await sql(
       `

--- a/_/apps/web/src/app/api/units/serial/[serial]/route.js
+++ b/_/apps/web/src/app/api/units/serial/[serial]/route.js
@@ -7,6 +7,13 @@ export async function GET(request, { params }) {
     return Response.json({ error: "Serial number is required" }, { status: 400 });
   }
 
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+
+  if (!token) {
+    return Response.json({ error: "Token is required" }, { status: 401 });
+  }
+
   try {
     // Get unit by serial number with limited information for public access
     const [unit] = await sql`
@@ -45,7 +52,7 @@ export async function GET(request, { params }) {
         c.industry
       FROM units u
       JOIN companies c ON u.company_id = c.id
-      WHERE u.serial_number = ${serial} AND u.is_active = true
+      WHERE u.serial_number = ${serial} AND u.access_token = ${token} AND u.is_active = true
     `;
 
     if (!unit) {

--- a/_/apps/web/src/app/unit/[serial]/page.jsx
+++ b/_/apps/web/src/app/unit/[serial]/page.jsx
@@ -28,6 +28,11 @@ export default function PublicUnitPage({ params }) {
   const [locationError, setLocationError] = useState(null);
   const { data: user, loading: userLoading } = useUser();
 
+  const token =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("token")
+      : null;
+
   // Log access when page loads
   useEffect(() => {
     const logAccess = async () => {
@@ -54,9 +59,11 @@ export default function PublicUnitPage({ params }) {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["public-unit", serial],
+    queryKey: ["public-unit", serial, token],
     queryFn: async () => {
-      const response = await fetch(`/api/units/serial/${serial}`);
+      const response = await fetch(
+        `/api/units/serial/${serial}?token=${token}`,
+      );
       if (!response.ok) {
         throw new Error(
           `Failed to fetch unit: ${response.status} ${response.statusText}`,

--- a/_/apps/web/src/components/Unit/UnitQRCodeCard.jsx
+++ b/_/apps/web/src/components/Unit/UnitQRCodeCard.jsx
@@ -33,7 +33,9 @@ export function UnitQRCodeCard({ unit }) {
         <p className="text-sm text-gray-600 mb-4">
           QR code links to:{" "}
           <span className="font-mono text-xs bg-gray-100 px-2 py-1 rounded">
-            /unit/{unit?.serial_number_engine || "ENGINE_SERIAL"}
+            {`/unit/${unit?.serial_number_engine || "ENGINE_SERIAL"}?token=${
+              unit?.access_token || "TOKEN"
+            }`}
           </span>
         </p>
         <p className="text-sm text-gray-600 mb-4">


### PR DESCRIPTION
## Summary
- use crypto.randomUUID for unit access token creation
- add QR code API endpoint that persists tokens and encodes tokenised links
- validate access tokens when serving public unit data

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: react-router: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a6a0a24cc0832a92f95bebfd43a2a3