### PR TITLE
feat(api): add role-based auth middleware

### DIFF
--- a/_/apps/web/src/app/api/assignments/[id]/route.js
+++ b/_/apps/web/src/app/api/assignments/[id]/route.js
@@ -1,8 +1,12 @@
 import sql from "@/app/api/utils/sql";
+import { requireRole } from "@/app/api/utils/auth-middleware";
 
 // Get assignment by ID
 export async function GET(request, { params }) {
   try {
+    const authResult = await requireRole();
+    if (authResult instanceof Response) return authResult;
+
     const { id } = params;
 
     const assignments = await sql(`
@@ -47,6 +51,9 @@ export async function GET(request, { params }) {
 // Update assignment (start, complete, add notes)
 export async function PUT(request, { params }) {
   try {
+    const authResult = await requireRole();
+    if (authResult instanceof Response) return authResult;
+
     const { id } = params;
     const data = await request.json();
 
@@ -142,6 +149,9 @@ export async function PUT(request, { params }) {
 // Delete assignment (unassign task)
 export async function DELETE(request, { params }) {
   try {
+    const authResult = await requireRole();
+    if (authResult instanceof Response) return authResult;
+
     const { id } = params;
 
     // Get assignment info first

--- a/_/apps/web/src/app/api/assignments/route.js
+++ b/_/apps/web/src/app/api/assignments/route.js
@@ -1,8 +1,12 @@
 import sql from "@/app/api/utils/sql";
+import { requireRole } from "@/app/api/utils/auth-middleware";
 
 // Get all assignments with task, teknisi, and supervisor info
 export async function GET(request) {
   try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
     const url = new URL(request.url);
     const supervisor_id = url.searchParams.get("supervisor_id");
     const teknisi_id = url.searchParams.get("teknisi_id");
@@ -77,6 +81,9 @@ export async function GET(request) {
 // Create new assignment
 export async function POST(request) {
   try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
     const data = await request.json();
     const { task_id, teknisi_id, supervisor_id, notes } = data;
 

--- a/_/apps/web/src/app/api/companies/route.js
+++ b/_/apps/web/src/app/api/companies/route.js
@@ -1,9 +1,12 @@
 import sql from "@/app/api/utils/sql";
-import { auth } from "@/auth";
+import { requireRole } from "@/app/api/utils/auth-middleware";
 
 // Get all companies
 export async function GET(request) {
   try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
     const url = new URL(request.url);
     const search = url.searchParams.get("search");
 
@@ -32,6 +35,9 @@ export async function GET(request) {
 // Create new company
 export async function POST(request) {
   try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
     const data = await request.json();
 
     if (!data.name) {

--- a/_/apps/web/src/app/api/tasks/[id]/route.js
+++ b/_/apps/web/src/app/api/tasks/[id]/route.js
@@ -1,8 +1,12 @@
 import sql from "@/app/api/utils/sql";
+import { requireRole } from "@/app/api/utils/auth-middleware";
 
 // Get single task
 export async function GET(request, { params }) {
   try {
+    const authResult = await requireRole();
+    if (authResult instanceof Response) return authResult;
+
     const { id } = params;
 
     const result = await sql(
@@ -42,6 +46,9 @@ export async function GET(request, { params }) {
 // Update task
 export async function PUT(request, { params }) {
   try {
+    const authResult = await requireRole();
+    if (authResult instanceof Response) return authResult;
+
     const { id } = params;
     const data = await request.json();
 
@@ -137,6 +144,9 @@ export async function PUT(request, { params }) {
 // Delete task (soft delete by marking as closed)
 export async function DELETE(request, { params }) {
   try {
+    const authResult = await requireRole();
+    if (authResult instanceof Response) return authResult;
+
     const { id } = params;
 
     const result = await sql(

--- a/_/apps/web/src/app/api/tasks/route.js
+++ b/_/apps/web/src/app/api/tasks/route.js
@@ -1,13 +1,11 @@
 import sql from "@/app/api/utils/sql";
-import { auth } from "@/auth";
+import { requireRole } from "@/app/api/utils/auth-middleware";
 
 // Get all tasks
 export async function GET(request) {
   try {
-    const session = await auth();
-    if (!session) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await requireRole();
+    if (session instanceof Response) return session;
 
     const url = new URL(request.url);
     const search = url.searchParams.get("search") || "";
@@ -167,6 +165,9 @@ export async function GET(request) {
 // Create new task
 export async function POST(request) {
   try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
     const data = await request.json();
 
     // Validate required fields

--- a/_/apps/web/src/app/api/units/[id]/route.js
+++ b/_/apps/web/src/app/api/units/[id]/route.js
@@ -1,9 +1,12 @@
 import sql from "@/app/api/utils/sql";
-import { auth } from "@/auth";
+import { requireRole } from "@/app/api/utils/auth-middleware";
 
 // Get single unit
 export async function GET(request, { params }) {
   try {
+    const authResult = await requireRole();
+    if (authResult instanceof Response) return authResult;
+
     const { id } = params;
 
     const units = await sql`
@@ -57,10 +60,8 @@ export async function GET(request, { params }) {
 // Update unit
 export async function PUT(request, { params }) {
   try {
-    const session = await auth();
-    if (!session?.user) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await requireRole();
+    if (session instanceof Response) return session;
 
     const { id } = params;
     const data = await request.json();
@@ -157,10 +158,8 @@ export async function PUT(request, { params }) {
 // Delete unit (soft delete)
 export async function DELETE(request, { params }) {
   try {
-    const session = await auth();
-    if (!session?.user) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await requireRole();
+    if (session instanceof Response) return session;
 
     const { id } = params;
 

--- a/_/apps/web/src/app/api/units/route.js
+++ b/_/apps/web/src/app/api/units/route.js
@@ -1,10 +1,13 @@
 import sql from "@/app/api/utils/sql";
-import { auth } from "@/auth";
+import { requireRole } from "@/app/api/utils/auth-middleware";
 import crypto from "crypto";
 
 // Get all units with company info
 export async function GET(request) {
   try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
     const url = new URL(request.url);
     const search = url.searchParams.get("search");
 
@@ -50,10 +53,8 @@ export async function GET(request) {
 // Create new unit
 export async function POST(request) {
   try {
-    const session = await auth();
-    if (!session?.user) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const session = await requireRole();
+    if (session instanceof Response) return session;
 
     const data = await request.json();
 

--- a/_/apps/web/src/app/api/utils/auth-middleware.js
+++ b/_/apps/web/src/app/api/utils/auth-middleware.js
@@ -1,0 +1,21 @@
+import { auth } from "@/auth";
+
+const ROLE_ALIAS = {
+  technician: "teknisi",
+};
+
+const DEFAULT_ROLES = ["admin", "sales", "supervisor", "technician", "teknisi"];
+
+export async function requireRole(roles = DEFAULT_ROLES) {
+  const session = await auth();
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const normalizedRoles = roles.map((role) => ROLE_ALIAS[role] || role);
+  if (!normalizedRoles.includes(session.user.role)) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return session;
+}


### PR DESCRIPTION
## Summary
- add shared `requireRole` helper to enforce authenticated roles
- protect companies, tasks, units, and assignments API routes with role checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: react-router: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6aab01480832a98d93c7cc9d3af60