### PR TITLE
feat: add service log module

### DIFF
--- a/_/apps/web/src/app/api/service-logs/[id]/route.js
+++ b/_/apps/web/src/app/api/service-logs/[id]/route.js
@@ -1,0 +1,157 @@
+import sql from "@/app/api/utils/sql";
+import { requireRole } from "@/app/api/utils/auth-middleware";
+import { z } from "zod";
+
+// Get single service log with materials and photos
+export async function GET(request, { params }) {
+  try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
+    const { id } = params;
+
+    const logs = await sql`
+      SELECT sl.*, u.unit_name
+      FROM service_logs sl
+      LEFT JOIN units u ON sl.unit_id = u.id
+      WHERE sl.id = ${id}
+    `;
+
+    if (logs.length === 0) {
+      return Response.json({ error: "Service log not found" }, { status: 404 });
+    }
+
+    const materials = await sql`
+      SELECT slm.material_id, slm.quantity, m.name as material_name
+      FROM service_log_materials slm
+      LEFT JOIN materials m ON slm.material_id = m.id
+      WHERE slm.service_log_id = ${id}
+    `;
+
+    const photos = await sql`
+      SELECT url FROM service_log_photos WHERE service_log_id = ${id}
+    `;
+
+    return Response.json({
+      service_log: {
+        ...logs[0],
+        materials,
+        photos,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching service log:", error);
+    return Response.json(
+      { error: "Failed to fetch service log" },
+      { status: 500 },
+    );
+  }
+}
+
+// Update a service log and adjust stock
+export async function PUT(request, { params }) {
+  try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
+    const { id } = params;
+    const bodySchema = z.object({
+      hour_meter: z.number().optional(),
+      notes: z.string().optional(),
+      materials: z
+        .array(
+          z.object({
+            material_id: z.number(),
+            quantity: z.number().positive(),
+          }),
+        )
+        .optional()
+        .default([]),
+      photos: z.array(z.string()).optional().default([]),
+    });
+
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return Response.json(
+        { error: "Invalid input", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const { hour_meter, notes, materials, photos } = parsed.data;
+
+    await sql.transaction(async (tx) => {
+      await tx`
+        UPDATE service_logs
+        SET hour_meter = COALESCE(${hour_meter}, hour_meter),
+            notes = COALESCE(${notes}, notes)
+        WHERE id = ${id}
+      `;
+
+      const existing = await tx`
+        SELECT material_id, quantity FROM service_log_materials
+        WHERE service_log_id = ${id}
+      `;
+      for (const m of existing) {
+        await tx`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
+      }
+      await tx`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
+
+      for (const m of materials) {
+        await tx`
+          INSERT INTO service_log_materials (service_log_id, material_id, quantity)
+          VALUES (${id}, ${m.material_id}, ${m.quantity})
+        `;
+        await tx`
+          UPDATE materials SET stock = stock - ${m.quantity} WHERE id = ${m.material_id}
+        `;
+      }
+
+      await tx`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
+      for (const url of photos) {
+        await tx`
+          INSERT INTO service_log_photos (service_log_id, url)
+          VALUES (${id}, ${url})
+        `;
+      }
+    });
+
+    return Response.json({ message: "Service log updated" });
+  } catch (error) {
+    console.error("Error updating service log:", error);
+    return Response.json(
+      { error: "Failed to update service log" },
+      { status: 500 },
+    );
+  }
+}
+
+// Delete a service log and restock materials
+export async function DELETE(request, { params }) {
+  try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
+    const { id } = params;
+
+    await sql.transaction(async (tx) => {
+      const materials = await tx`
+        SELECT material_id, quantity FROM service_log_materials
+        WHERE service_log_id = ${id}
+      `;
+      for (const m of materials) {
+        await tx`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
+      }
+      await tx`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
+      await tx`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
+      await tx`DELETE FROM service_logs WHERE id = ${id}`;
+    });
+
+    return Response.json({ message: "Service log deleted" });
+  } catch (error) {
+    console.error("Error deleting service log:", error);
+    return Response.json(
+      { error: "Failed to delete service log" },
+      { status: 500 },
+    );
+  }
+}

--- a/_/apps/web/src/app/api/service-logs/route.js
+++ b/_/apps/web/src/app/api/service-logs/route.js
@@ -1,0 +1,95 @@
+import sql from "@/app/api/utils/sql";
+import { requireRole } from "@/app/api/utils/auth-middleware";
+import { z } from "zod";
+
+// List service logs
+export async function GET() {
+  try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
+    const logs = await sql`
+      SELECT sl.*, u.unit_name
+      FROM service_logs sl
+      LEFT JOIN units u ON sl.unit_id = u.id
+      ORDER BY sl.created_at DESC
+    `;
+
+    return Response.json({ service_logs: logs });
+  } catch (error) {
+    console.error("Error fetching service logs:", error);
+    return Response.json(
+      { error: "Failed to fetch service logs" },
+      { status: 500 },
+    );
+  }
+}
+
+// Create service log with materials and photos
+export async function POST(request) {
+  try {
+    const session = await requireRole();
+    if (session instanceof Response) return session;
+
+    const bodySchema = z.object({
+      unit_id: z.number(),
+      hour_meter: z.number(),
+      notes: z.string().optional(),
+      materials: z
+        .array(
+          z.object({
+            material_id: z.number(),
+            quantity: z.number().positive(),
+          }),
+        )
+        .optional()
+        .default([]),
+      photos: z.array(z.string()).optional().default([]),
+    });
+
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return Response.json(
+        { error: "Invalid input", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const { unit_id, hour_meter, notes, materials, photos } = parsed.data;
+
+    const log = await sql.transaction(async (tx) => {
+      const [inserted] = await tx`
+        INSERT INTO service_logs (unit_id, hour_meter, notes)
+        VALUES (${unit_id}, ${hour_meter}, ${notes || null})
+        RETURNING id, unit_id, hour_meter, notes, created_at
+      `;
+
+      for (const m of materials) {
+        await tx`
+          INSERT INTO service_log_materials (service_log_id, material_id, quantity)
+          VALUES (${inserted.id}, ${m.material_id}, ${m.quantity})
+        `;
+        await tx`
+          UPDATE materials SET stock = stock - ${m.quantity}
+          WHERE id = ${m.material_id}
+        `;
+      }
+
+      for (const url of photos) {
+        await tx`
+          INSERT INTO service_log_photos (service_log_id, url)
+          VALUES (${inserted.id}, ${url})
+        `;
+      }
+
+      return inserted;
+    });
+
+    return Response.json({ service_log: log }, { status: 201 });
+  } catch (error) {
+    console.error("Error creating service log:", error);
+    return Response.json(
+      { error: "Failed to create service log" },
+      { status: 500 },
+    );
+  }
+}

--- a/_/apps/web/src/app/service-logs/[id]/page.jsx
+++ b/_/apps/web/src/app/service-logs/[id]/page.jsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { ArrowLeft } from "lucide-react";
+import Header from "@/components/Header";
+
+const queryClient = new QueryClient();
+
+function ServiceLogDetailContent() {
+  const id =
+    typeof window !== "undefined" ? window.location.pathname.split("/").pop() : null;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["service-log", id],
+    queryFn: async () => {
+      const res = await fetch(`/api/service-logs/${id}`);
+      if (!res.ok) throw new Error("Failed to fetch service log");
+      return res.json();
+    },
+    enabled: !!id,
+  });
+
+  if (isLoading) return <div className="p-4">Loading...</div>;
+  if (error) return <div className="p-4">Failed to load service log</div>;
+
+  const log = data?.service_log;
+
+  return (
+    <div className="p-4 space-y-4">
+      <a href="/service-logs" className="flex items-center text-sm text-blue-600">
+        <ArrowLeft className="mr-1" size={16} /> Back
+      </a>
+      <h1 className="text-2xl font-bold">Service Log Detail</h1>
+      {log && (
+        <div className="space-y-4">
+          <div>
+            <span className="font-medium">Unit:</span> {log.unit_name || `Unit ${log.unit_id}`}
+          </div>
+          <div>
+            <span className="font-medium">Hour Meter:</span> {log.hour_meter}
+          </div>
+          {log.materials?.length > 0 && (
+            <div>
+              <h2 className="font-medium mb-2">Materials</h2>
+              <ul className="list-disc list-inside">
+                {log.materials.map((m) => (
+                  <li key={m.material_id}>
+                    {m.material_name || `Material ${m.material_id}`} - {m.quantity}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {log.photos?.length > 0 && (
+            <div>
+              <h2 className="font-medium mb-2">Photos</h2>
+              <div className="flex flex-wrap gap-2">
+                {log.photos.map((p, i) => (
+                  <img
+                    key={i}
+                    src={p.url}
+                    alt="Photo"
+                    className="h-32 w-32 object-cover rounded"
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ServiceLogDetailPage() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Header />
+      <ServiceLogDetailContent />
+    </QueryClientProvider>
+  );
+}

--- a/_/apps/web/src/app/service-logs/page.jsx
+++ b/_/apps/web/src/app/service-logs/page.jsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import Header from "@/components/Header";
+
+const queryClient = new QueryClient();
+
+function ServiceLogsContent() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["service-logs"],
+    queryFn: async () => {
+      const res = await fetch("/api/service-logs");
+      if (!res.ok) throw new Error("Failed to fetch service logs");
+      return res.json();
+    },
+  });
+
+  if (isLoading) return <div className="p-4">Loading...</div>;
+  if (error) return <div className="p-4">Failed to load service logs</div>;
+
+  const logs = data?.service_logs || [];
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Service Logs</h1>
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left">Unit</th>
+            <th className="px-4 py-2 text-left">Hour Meter</th>
+            <th className="px-4 py-2 text-left">Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log) => (
+            <tr key={log.id} className="border-t">
+              <td className="px-4 py-2">
+                <a
+                  href={`/service-logs/${log.id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  {log.unit_name || `Unit ${log.unit_id}`}
+                </a>
+              </td>
+              <td className="px-4 py-2">{log.hour_meter}</td>
+              <td className="px-4 py-2">
+                {log.created_at &&
+                  new Date(log.created_at).toLocaleDateString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function ServiceLogsPage() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Header />
+      <ServiceLogsContent />
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add service log API with transactional stock updates
- implement service log list and detail pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: react-router: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6af32ba48832a8ad3afb8ef309562