### PR TITLE
docs: add setup instructions and runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,37 @@
 # asset_management_ver3
 
+## Setup
+
+### Requirements
+- Node.js 20+
+- Bun (for the web app)
+- npm & Expo CLI (for the mobile app)
+- PostgreSQL database
+- Redis server
+
+### Environment Variables
+Create a `.env` file in each app directory with the following keys.
+
+#### Web app
+- `DATABASE_URL` – PostgreSQL connection string.
+- `AUTH_SECRET` – session secret for authentication.
+- `AUTH_URL` – base URL used by auth callbacks.
+- `REDIS_URL` – Redis connection string.
+- `CORS_ORIGINS` – comma separated list of allowed origins.
+- `NEXT_PUBLIC_PROJECT_GROUP_ID` – project group identifier shared with clients.
+- `NEXT_PUBLIC_CREATE_BASE_URL` – base URL for Create API requests.
+- `NEXT_PUBLIC_CREATE_HOST` – host name forwarded to the API.
+
+#### Mobile app
+- `EXPO_PUBLIC_PROJECT_GROUP_ID` – project group identifier used by the client.
+- `EXPO_PUBLIC_BASE_URL` – base API URL.
+- `EXPO_PUBLIC_PROXY_BASE_URL` – proxy used for auth flow.
+- `EXPO_PUBLIC_UPLOADCARE_PUBLIC_KEY` – Uploadcare public key for file uploads.
+- `EXPO_PUBLIC_BASE_CREATE_USER_CONTENT_URL` – base URL for uploaded content.
+- `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` – Google Maps key for map components.
+- `EXPO_PUBLIC_HOST` – host name forwarded to the API.
+- `EXPO_PUBLIC_LOGS_ENDPOINT` – optional endpoint for remote logs.
+
 ## Database Setup
 
 This project uses [Prisma](https://www.prisma.io/) for managing PostgreSQL migrations and seeding.
@@ -17,3 +49,23 @@ bun run prisma:seed
 ```
 
 The seed script populates sample companies, contacts, units and service logs.
+
+## Running the Web App
+
+```
+cd _/apps/web
+bun install
+bun run dev
+```
+
+Runs the Vite/React dev server on `http://localhost:3000` by default. Use `bun run build` for production builds.
+
+## Running the Mobile App
+
+```
+cd _/apps/mobile
+npm install
+npx expo start
+```
+
+This launches Expo for local development. Use `expo build` or `eas build` for production releases.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,16 @@
+# Runbook
+
+## Backup Procedures
+- Use `pg_dump $DATABASE_URL > backups/$(date +%F).sql` to back up the PostgreSQL database.
+- For Redis, run `redis-cli --rdb` or enable snapshotting to capture the current dataset.
+- Store backups in off-site storage such as S3 with appropriate retention policies.
+
+## Restore Procedures
+- Restore PostgreSQL with `psql $DATABASE_URL < path/to/backup.sql`.
+- Restore Redis by loading the RDB snapshot or piping commands with `redis-cli --pipe < dump.rdb`.
+- After restoration, run smoke tests and verify application functionality.
+
+## Scaling Procedures
+- **Web app:** Build production assets with `bun run build` and deploy multiple instances behind a load balancer. Scale background workers by running additional `bun run reminder-worker` processes.
+- **Mobile app:** Produce release builds using Expo or EAS and ensure API URLs point to the load-balanced backend.
+- **Database:** Increase PostgreSQL instance size or enable read replicas as load grows. Monitor Redis memory usage and adjust resources accordingly.


### PR DESCRIPTION
## Summary
- document setup requirements, environment variables, and run commands for web and mobile apps
- add runbook covering backup, restore, and scaling procedures

## Testing
- `npm test` (web) *(fails: vitest not found)*
- `npm test` (mobile) *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b9b1479c832ab90490904ccbceaf