### PR TITLE
fix: build route import URL

### DIFF
--- a/_/apps/web/__create/route-builder.ts
+++ b/_/apps/web/__create/route-builder.ts
@@ -1,6 +1,6 @@
 import { readdir, stat } from 'node:fs/promises';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, isAbsolute } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Hono } from 'hono';
 import type { Handler } from 'hono/types';
 import updatedFetch from '../src/__create/fetch';
@@ -84,8 +84,10 @@ async function registerRoutes() {
   for (const routeFile of routeFiles) {
     try {
       // Ensure the path is compatible with dynamic import on Windows
-      const importPath = routeFile.startsWith('/') ? `file://${routeFile}` : routeFile;
-      const route = await import(/* @vite-ignore */ `${importPath}?update=${Date.now()}`);
+      const importUrl = isAbsolute(routeFile)
+        ? pathToFileURL(routeFile).href
+        : routeFile;
+      const route = await import(/* @vite-ignore */ `${importUrl}?update=${Date.now()}`);
 
       const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'];
       for (const method of methods) {
@@ -97,7 +99,7 @@ async function registerRoutes() {
               const params = c.req.param();
               if (import.meta.env.DEV) {
                 const updatedRoute = await import(
-                  /* @vite-ignore */ `${routeFile}?update=${Date.now()}`
+                  /* @vite-ignore */ `${importUrl}?update=${Date.now()}`
                 );
                 return await updatedRoute[method](c.req.raw, { params });
               }


### PR DESCRIPTION
## Summary
- fix dynamic import by using `path.isAbsolute` and `pathToFileURL` for route files

## Testing
- `npm test`
- `npm run dev` *(fails: connect ECONNREFUSED 127.0.0.1:6379 when hitting /api/auth/session)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0d319bc832aac498a8ab8712818