### PR TITLE
Guard session fetch against non‑JSON responses

### DIFF
--- a/_/apps/web/patches/@hono+auth-js+1.0.16.patch
+++ b/_/apps/web/patches/@hono+auth-js+1.0.16.patch
@@ -1,0 +1,40 @@
+diff --git a/node_modules/@hono/auth-js/dist/react.cjs b/node_modules/@hono/auth-js/dist/react.cjs
+index 04dde10..7d26b8a 100644
+--- a/node_modules/@hono/auth-js/dist/react.cjs
++++ b/node_modules/@hono/auth-js/dist/react.cjs
+@@ -67,6 +67,15 @@ async function fetchData(path, config, logger2, req = {}) {
+       options.method = "POST";
+     }
+     const res = await fetch(url, options);
++    const contentType = res.headers.get("content-type");
++    if (!contentType || !contentType.includes("application/json")) {
++      logger2.error(
++        new ClientFetchError(
++          `Unexpected response content-type: ${contentType || "unknown"}`
++        )
++      );
++      return null;
++    }
+     const data = await res.json();
+     if (!res.ok) {
+       throw data;
+diff --git a/node_modules/@hono/auth-js/dist/react.js b/node_modules/@hono/auth-js/dist/react.js
+index 5dbdf59..4ff05a4 100644
+--- a/node_modules/@hono/auth-js/dist/react.js
++++ b/node_modules/@hono/auth-js/dist/react.js
+@@ -24,6 +24,15 @@ async function fetchData(path, config, logger2, req = {}) {
+       options.method = "POST";
+     }
+     const res = await fetch(url, options);
++    const contentType = res.headers.get("content-type");
++    if (!contentType || !contentType.includes("application/json")) {
++      logger2.error(
++        new ClientFetchError(
++          `Unexpected response content-type: ${contentType || "unknown"}`
++        )
++      );
++      return null;
++    }
+     const data = await res.json();
+     if (!res.ok) {
+       throw data;

--- a/_/apps/web/src/app/api/vitest.config.ts
+++ b/_/apps/web/src/app/api/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '../../'),
+      '@auth/create/react': '@hono/auth-js/react',
+      '@auth/create': path.resolve(__dirname, '../../__create/@auth/create.js'),
     },
   },
 });

--- a/_/apps/web/test/getSessionHtmlResponse.test.ts
+++ b/_/apps/web/test/getSessionHtmlResponse.test.ts
@@ -1,0 +1,20 @@
+import { getSession, authConfigManager } from '@hono/auth-js/react';
+import { vi, describe, expect, test } from 'vitest';
+
+describe('getSession', () => {
+  test('returns null when response is not JSON', async () => {
+    authConfigManager.setConfig({ baseUrl: '', basePath: '' });
+    const json = vi.fn();
+    const originalFetch = global.fetch;
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'text/html' },
+      json,
+    });
+    const session = await getSession();
+    expect(session).toBeNull();
+    expect(json).not.toHaveBeenCalled();
+    global.fetch = originalFetch;
+  });
+});

--- a/_/apps/web/vitest.config.ts
+++ b/_/apps/web/vitest.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@auth/create/react': '@hono/auth-js/react',
+      '@auth/create': path.resolve(__dirname, './src/__create/@auth/create.js'),
     },
   },
   esbuild: {


### PR DESCRIPTION
## Summary
- patch `@hono/auth-js` (`@auth/create/react` alias) to check the `content-type` header before parsing session responses
- expose auth aliases to Vitest configs
- add regression test ensuring HTML responses return `null` instead of crashing

## Testing
- `bun test test/getSessionHtmlResponse.test.ts`
- `bun test` *(fails: Cannot find module '@auth/create' from 'src/auth.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a6d4fe1008832ab2cde2a8836b880b