### PR TITLE
Gracefully handle missing Redis

### DIFF
--- a/_/apps/web/src/app/api/reminders/[id]/route.js
+++ b/_/apps/web/src/app/api/reminders/[id]/route.js
@@ -1,7 +1,7 @@
 import sql from "@/app/api/utils/sql";
 import { requireRole } from "@/app/api/utils/auth-middleware";
 import { z } from "zod";
-import { scheduleReminder } from "@/jobs/reminderQueue";
+import { scheduleReminder, reminderQueue } from "@/jobs/reminderQueue";
 
 export async function GET(request, { params }) {
   const session = await requireRole(["sales", "admin"]);
@@ -53,7 +53,11 @@ export async function PUT(request, { params }) {
   }
   const reminder = result[0];
   if (data.remind_at) {
-    await scheduleReminder(reminder);
+    if (reminderQueue) {
+      await scheduleReminder(reminder);
+    } else {
+      console.warn("Reminder queue not initialized; skipping scheduling");
+    }
   }
   return Response.json({ reminder });
 }

--- a/_/apps/web/src/app/api/reminders/route.js
+++ b/_/apps/web/src/app/api/reminders/route.js
@@ -1,7 +1,7 @@
 import sql from "@/app/api/utils/sql";
 import { requireRole } from "@/app/api/utils/auth-middleware";
 import { z } from "zod";
-import { scheduleReminder } from "@/jobs/reminderQueue";
+import { scheduleReminder, reminderQueue } from "@/jobs/reminderQueue";
 
 // List reminders or create new reminder
 export async function GET(request) {
@@ -49,7 +49,11 @@ export async function POST(request) {
   );
 
   const reminder = result[0];
-  await scheduleReminder(reminder);
+  if (reminderQueue) {
+    await scheduleReminder(reminder);
+  } else {
+    console.warn("Reminder queue not initialized; skipping scheduling");
+  }
 
   return Response.json({ reminder }, { status: 201 });
 }

--- a/_/apps/web/src/jobs/reminderQueue.js
+++ b/_/apps/web/src/jobs/reminderQueue.js
@@ -1,27 +1,55 @@
 import { Queue } from "bullmq";
 import Redis from "ioredis";
 
-const connection = new Redis(process.env.REDIS_URL || "redis://localhost:6379");
+export let reminderQueue;
 
-export const reminderQueue = new Queue("reminders", { connection });
+async function initQueue() {
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    console.warn(
+      "REDIS_URL not set; skipping reminder queue initialization",
+    );
+    return;
+  }
+
+  try {
+    const connection = new Redis(url);
+    await connection.ping();
+    reminderQueue = new Queue("reminders", { connection });
+  } catch (err) {
+    console.warn(
+      "Failed to connect to Redis, skipping reminder queue initialization",
+      err,
+    );
+  }
+}
+
+await initQueue();
 
 export async function scheduleReminder(reminder) {
+  if (!reminderQueue) {
+    console.warn("Reminder queue not initialized; skipping scheduling");
+    return;
+  }
   const delay = new Date(reminder.remind_at).getTime() - Date.now();
   await reminderQueue.add(
     "send-reminder",
     { reminderId: reminder.id },
-    { delay: Math.max(delay, 0) }
+    { delay: Math.max(delay, 0) },
   );
 }
 
 async function scheduleDailyProcessing() {
+  if (!reminderQueue) return;
   await reminderQueue.add(
     "process-reminders",
     {},
-    { repeat: { cron: "0 0 * * *" }, jobId: "process-reminders" }
+    { repeat: { cron: "0 0 * * *" }, jobId: "process-reminders" },
   );
 }
 
-scheduleDailyProcessing().catch((err) => {
-  console.error("Failed to schedule daily reminder processing", err);
-});
+if (reminderQueue) {
+  scheduleDailyProcessing().catch((err) => {
+    console.error("Failed to schedule daily reminder processing", err);
+  });
+}

--- a/_/apps/web/src/jobs/reminderWorker.js
+++ b/_/apps/web/src/jobs/reminderWorker.js
@@ -2,29 +2,50 @@ import { Worker } from "bullmq";
 import Redis from "ioredis";
 import sql from "../app/api/utils/sql.js";
 
-const connection = new Redis(process.env.REDIS_URL || "redis://localhost:6379");
+export let reminderWorker;
 
-export const reminderWorker = new Worker(
-  "reminders",
-  async (job) => {
-    if (job.name === "send-reminder") {
-      const { reminderId } = job.data;
-      const result = await sql`SELECT id, title, remind_at FROM reminders WHERE id = ${reminderId}`;
-      if (result.length) {
-        const reminder = result[0];
-        console.log(`Reminder due: ${reminder.title} at ${reminder.remind_at}`);
-      }
-    }
-    if (job.name === "process-reminders") {
-      const reminders = await sql`SELECT id, title, remind_at FROM reminders WHERE remind_at <= NOW()`;
-      reminders.forEach((r) =>
-        console.log(`Processing reminder: ${r.title} - ${r.remind_at}`),
-      );
-    }
-  },
-  { connection }
-);
+async function initWorker() {
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    console.warn(
+      "REDIS_URL not set; skipping reminder worker initialization",
+    );
+    return;
+  }
 
-reminderWorker.on("failed", (job, err) => {
-  console.error(`Reminder job ${job.id} failed`, err);
-});
+  try {
+    const connection = new Redis(url);
+    await connection.ping();
+    reminderWorker = new Worker(
+      "reminders",
+      async (job) => {
+        if (job.name === "send-reminder") {
+          const { reminderId } = job.data;
+          const result = await sql`SELECT id, title, remind_at FROM reminders WHERE id = ${reminderId}`;
+          if (result.length) {
+            const reminder = result[0];
+            console.log(`Reminder due: ${reminder.title} at ${reminder.remind_at}`);
+          }
+        }
+        if (job.name === "process-reminders") {
+          const reminders = await sql`SELECT id, title, remind_at FROM reminders WHERE remind_at <= NOW()`;
+          reminders.forEach((r) =>
+            console.log(`Processing reminder: ${r.title} - ${r.remind_at}`),
+          );
+        }
+      },
+      { connection },
+    );
+
+    reminderWorker.on("failed", (job, err) => {
+      console.error(`Reminder job ${job.id} failed`, err);
+    });
+  } catch (err) {
+    console.warn(
+      "Failed to connect to Redis, skipping reminder worker initialization",
+      err,
+    );
+  }
+}
+
+await initWorker();


### PR DESCRIPTION
## Summary
- Wrap Redis initialization for reminder queue and worker in try/catch and attempt connection
- Skip queue setup when Redis is unavailable and log warnings instead of throwing
- Guard reminder scheduling routes to only enqueue when a queue connection exists

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6d981d6a0832a805bf581067d260c