### PR TITLE
Ensure API requests return JSON error responses

### DIFF
--- a/_/apps/web/__create/index.ts
+++ b/_/apps/web/__create/index.ts
@@ -51,7 +51,10 @@ app.use('*', (c, next) => {
 app.use(contextStorage());
 
 app.onError((err, c) => {
-  if (c.req.method !== 'GET') {
+  const acceptsJSON = c.req.header('Accept')?.includes('application/json');
+  const isAPIRequest = c.req.path.startsWith(API_BASENAME) || acceptsJSON;
+
+  if (isAPIRequest) {
     return c.json(
       {
         error: 'An error occurred in your app',
@@ -60,6 +63,7 @@ app.onError((err, c) => {
       500
     );
   }
+
   return c.html(getHTMLForErrorPage(err), 200);
 });
 


### PR DESCRIPTION
## Summary
- return JSON error bodies for API routes and JSON requests

## Testing
- `bun run test`
- `bun run build`
- `curl -i -H "Accept: application/json" http://localhost:4001/api/auth/session`


------
https://chatgpt.com/codex/tasks/task_e_68a6fcabda34832a90691c00f7f7577b