### PR TITLE
Add fallback for AUTH_URL https check

### DIFF
--- a/_/apps/web/src/__create/@auth/create.js
+++ b/_/apps/web/src/__create/@auth/create.js
@@ -7,8 +7,8 @@ export default function CreateAuth() {
 		const token = await getToken({
 			req: c.req.raw,
 			secret: process.env.AUTH_SECRET,
-			secureCookie: process.env.AUTH_URL.startsWith('https'),
-		});
+                        secureCookie: (process.env.AUTH_URL?.startsWith('https') ?? false),
+                });
 		if (token) {
 			return {
 				user: {

--- a/_/apps/web/src/app/api/auth/expo-web-success/route.js
+++ b/_/apps/web/src/app/api/auth/expo-web-success/route.js
@@ -4,15 +4,15 @@ export async function GET(request) {
 		getToken({
 			req: request,
 			secret: process.env.AUTH_SECRET,
-			secureCookie: process.env.AUTH_URL.startsWith('https'),
+                        secureCookie: (process.env.AUTH_URL?.startsWith('https') ?? false),
 			raw: true,
 		}),
 		getToken({
 			req: request,
 			secret: process.env.AUTH_SECRET,
-			secureCookie: process.env.AUTH_URL.startsWith('https'),
-		}),
-	]);
+                        secureCookie: (process.env.AUTH_URL?.startsWith('https') ?? false),
+                }),
+        ]);
 
 	if (!jwt) {
 		return new Response(

--- a/_/apps/web/src/app/api/auth/token/route.js
+++ b/_/apps/web/src/app/api/auth/token/route.js
@@ -4,15 +4,15 @@ export async function GET(request) {
 		getToken({
 			req: request,
 			secret: process.env.AUTH_SECRET,
-			secureCookie: process.env.AUTH_URL.startsWith('https'),
+                        secureCookie: (process.env.AUTH_URL?.startsWith('https') ?? false),
 			raw: true,
 		}),
 		getToken({
 			req: request,
 			secret: process.env.AUTH_SECRET,
-			secureCookie: process.env.AUTH_URL.startsWith('https'),
-		}),
-	]);
+                        secureCookie: (process.env.AUTH_URL?.startsWith('https') ?? false),
+                }),
+        ]);
 
 	if (!jwt) {
 		return new Response(JSON.stringify({ error: 'Unauthorized' }), {


### PR DESCRIPTION
## Summary
- guard AUTH_URL secureCookie checks with optional chaining

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a714b9d604832a8aff00f00bdf57eb