### PR TITLE
Require AUTH_SECRET env for auth endpoints

### DIFF
--- a/_/apps/web/.env.example
+++ b/_/apps/web/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for the web app
+AUTH_SECRET=your-auth-secret

--- a/_/apps/web/__create/index.ts
+++ b/_/apps/web/__create/index.ts
@@ -76,8 +76,10 @@ if (process.env.CORS_ORIGINS) {
   );
 }
 
-if (process.env.AUTH_SECRET) {
-  app.use(
+if (!process.env.AUTH_SECRET) {
+  throw new Error('AUTH_SECRET is required for auth endpoints');
+}
+app.use(
     '*',
     initAuthConfig((c) => ({
       secret: c.env.AUTH_SECRET,
@@ -206,10 +208,9 @@ if (process.env.AUTH_SECRET) {
             return null;
           },
         }),
-      ],
-    }))
-  );
-}
+        ],
+      }))
+    );
 app.all('/integrations/:path{.+}', async (c, next) => {
   const queryParams = c.req.query();
   const url = `${process.env.NEXT_PUBLIC_CREATE_BASE_URL ?? 'https://www.create.xyz'}/integrations/${c.req.param('path')}${Object.keys(queryParams).length > 0 ? `?${new URLSearchParams(queryParams).toString()}` : ''}`;


### PR DESCRIPTION
## Summary
- validate `AUTH_SECRET` is present before initializing auth
- always initialize auth configuration without conditional guard
- document `AUTH_SECRET` in web app `.env.example`

## Testing
- `bun run lint`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db AUTH_SECRET=test AUTH_URL=http://localhost REDIS_URL=redis://localhost:6379 CORS_ORIGINS=http://localhost NEXT_PUBLIC_PROJECT_GROUP_ID=test NEXT_PUBLIC_CREATE_BASE_URL=http://localhost NEXT_PUBLIC_CREATE_HOST=localhost bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68a714e50c9c832ab932118adc40e7d8