### PR TITLE
feat: add database URL startup validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@
 - Redis server
 
 ### Environment Variables
-Create a `.env` file in each app directory with the following keys.
+Create a `.env` file in each app directory with the following keys. Use the provided `.env.example` as a starting point and update the values for your environment.
 
 #### Web app
-- `DATABASE_URL` – PostgreSQL connection string.
+- `DATABASE_URL` – PostgreSQL connection string. Example:
+  `postgres://user:password@localhost:5432/asset_management`
+  The web server logs a detailed message and exits during startup if this variable is missing.
 - `AUTH_SECRET` – session secret for authentication.
 - `AUTH_URL` – base URL used by auth callbacks.
 - `REDIS_URL` – Redis connection string.

--- a/_/apps/web/.env.example
+++ b/_/apps/web/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the web app
+# DATABASE_URL should point to your PostgreSQL instance
+DATABASE_URL=postgres://user:password@localhost:5432/asset_management

--- a/_/apps/web/src/app/api/utils/sql.js
+++ b/_/apps/web/src/app/api/utils/sql.js
@@ -1,15 +1,19 @@
 import { neon } from '@neondatabase/serverless';
 
-const NullishQueryFunction = () => {
-  throw new Error(
-    'No database connection string was provided to `neon()`. Perhaps process.env.DATABASE_URL has not been set'
+const NullishQueryFunction = async () => {
+  console.error(
+    'No database connection string was provided to `neon()`. Set process.env.DATABASE_URL to connect to the database.',
   );
+  return new Response('Internal Server Error', { status: 500 });
 };
-NullishQueryFunction.transaction = () => {
-  throw new Error(
-    'No database connection string was provided to `neon()`. Perhaps process.env.DATABASE_URL has not been set'
+
+NullishQueryFunction.transaction = async () => {
+  console.error(
+    'No database connection string was provided to `neon()`. Set process.env.DATABASE_URL to connect to the database.',
   );
+  return new Response('Internal Server Error', { status: 500 });
 };
+
 const sql = process.env.DATABASE_URL ? neon(process.env.DATABASE_URL) : NullishQueryFunction;
 
 export default sql;

--- a/_/apps/web/vite.config.ts
+++ b/_/apps/web/vite.config.ts
@@ -13,6 +13,14 @@ import { nextPublicProcessEnv } from './plugins/nextPublicProcessEnv';
 import { restart } from './plugins/restart';
 import { restartEnvFileChange } from './plugins/restartEnvFileChange';
 
+// Ensure a database connection string is configured before starting the server.
+if (!process.env.DATABASE_URL) {
+  console.error(
+    'DATABASE_URL environment variable is required but was not provided. Please set it in your .env file.',
+  );
+  process.exit(1);
+}
+
 export default defineConfig({
   publicDir: 'public',
   // Keep them available via import.meta.env.NEXT_PUBLIC_*


### PR DESCRIPTION
## Summary
- ensure server exits early when `DATABASE_URL` is unset
- return friendly 500 response when database URL is missing
- add `.env.example` and document `DATABASE_URL`

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68a714f57208832abfec5d621c2f03b9