### PR TITLE
feat: add auth models and migration

### DIFF
--- a/_/apps/web/prisma/migrations/20250821124930_add-auth-tables/migration.sql
+++ b/_/apps/web/prisma/migrations/20250821124930_add-auth-tables/migration.sql
@@ -1,0 +1,68 @@
+-- CreateTable
+CREATE TABLE "public"."auth_users" (
+    "id" UUID NOT NULL,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" TIMESTAMP(3),
+    "image" TEXT,
+
+    CONSTRAINT "auth_users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."auth_accounts" (
+    "id" UUID NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+    "password" TEXT,
+
+    CONSTRAINT "auth_accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."auth_sessions" (
+    "id" UUID NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "auth_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."auth_verification_token" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auth_users_email_key" ON "public"."auth_users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auth_accounts_provider_providerAccountId_key" ON "public"."auth_accounts"("provider", "providerAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auth_sessions_sessionToken_key" ON "public"."auth_sessions"("sessionToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auth_verification_token_token_key" ON "public"."auth_verification_token"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auth_verification_token_identifier_token_key" ON "public"."auth_verification_token"("identifier", "token");
+
+-- AddForeignKey
+ALTER TABLE "public"."auth_accounts" ADD CONSTRAINT "auth_accounts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."auth_users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."auth_sessions" ADD CONSTRAINT "auth_sessions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."auth_users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/_/apps/web/prisma/schema.prisma
+++ b/_/apps/web/prisma/schema.prisma
@@ -66,3 +66,54 @@ model ServiceLog {
   notes     String?
   createdAt DateTime @default(now()) @map("created_at")
 }
+
+model AuthUser {
+  id            String         @id @default(uuid()) @db.Uuid
+  name          String?
+  email         String?        @unique
+  emailVerified DateTime?
+  image         String?
+  accounts      AuthAccount[]
+  sessions      AuthSession[]
+
+  @@map("auth_users")
+}
+
+model AuthAccount {
+  id                String    @id @default(uuid()) @db.Uuid
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refreshToken      String?   @map("refresh_token")
+  accessToken       String?   @map("access_token")
+  expiresAt         Int?      @map("expires_at")
+  tokenType         String?   @map("token_type")
+  scope             String?
+  idToken           String?   @map("id_token")
+  sessionState      String?   @map("session_state")
+  password          String?
+  user              AuthUser  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+  @@map("auth_accounts")
+}
+
+model AuthSession {
+  id           String    @id @default(uuid()) @db.Uuid
+  sessionToken String    @unique
+  userId       String
+  expires      DateTime
+  user         AuthUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("auth_sessions")
+}
+
+model AuthVerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+  @@map("auth_verification_token")
+}


### PR DESCRIPTION
## Summary
- add `AuthUser`, `AuthAccount`, `AuthSession`, and `AuthVerificationToken` models to Prisma schema
- generate SQL migration to create auth tables for `@auth/core`

## Testing
- `npx prisma migrate dev --name add-auth-tables` *(fails: Can't reach database server)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7151b4c08832ab19e25509a14b967