### PR TITLE
Configure auth cookies based on environment

### DIFF
--- a/_/apps/web/__create/index.ts
+++ b/_/apps/web/__create/index.ts
@@ -19,6 +19,8 @@ import { isAuthAction } from './is-auth-action';
 import { API_BASENAME, api } from './route-builder';
 neonConfig.webSocketConstructor = ws;
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 const als = new AsyncLocalStorage<{ requestId: string }>();
 
 for (const method of ['log', 'info', 'warn', 'error', 'debug'] as const) {
@@ -100,20 +102,20 @@ if (process.env.AUTH_SECRET) {
       cookies: {
         csrfToken: {
           options: {
-            secure: true,
-            sameSite: 'none',
+            secure: isProduction,
+            sameSite: isProduction ? 'none' : 'lax',
           },
         },
         sessionToken: {
           options: {
-            secure: true,
-            sameSite: 'none',
+            secure: isProduction,
+            sameSite: isProduction ? 'none' : 'lax',
           },
         },
         callbackUrl: {
           options: {
-            secure: true,
-            sameSite: 'none',
+            secure: isProduction,
+            sameSite: isProduction ? 'none' : 'lax',
           },
         },
       },


### PR DESCRIPTION
## Summary
- tie cookie security to production environment
- use `sameSite: 'lax'` outside production for local compatibility

## Testing
- `bun run lint`
- `bun run test` *(fails: vitest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7152bcf80832a86f42d1e7b1956e7