### PR TITLE
fix: specify UUID type for auth relations

### DIFF
--- a/_/apps/web/prisma/migrations/20250821151537_fix-auth-userid-type/migration.sql
+++ b/_/apps/web/prisma/migrations/20250821151537_fix-auth-userid-type/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "public"."auth_accounts" DROP CONSTRAINT "auth_accounts_userId_fkey";
+ALTER TABLE "public"."auth_sessions" DROP CONSTRAINT "auth_sessions_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."auth_accounts" ALTER COLUMN "userId" TYPE UUID USING "userId"::uuid;
+ALTER TABLE "public"."auth_sessions" ALTER COLUMN "userId" TYPE UUID USING "userId"::uuid;
+
+-- AddForeignKey
+ALTER TABLE "public"."auth_accounts" ADD CONSTRAINT "auth_accounts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."auth_users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."auth_sessions" ADD CONSTRAINT "auth_sessions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."auth_users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/_/apps/web/prisma/schema.prisma
+++ b/_/apps/web/prisma/schema.prisma
@@ -81,7 +81,7 @@ model AuthUser {
 
 model AuthAccount {
   id                String    @id @default(uuid()) @db.Uuid
-  userId            String
+  userId            String    @db.Uuid
   type              String
   provider          String
   providerAccountId String
@@ -102,7 +102,7 @@ model AuthAccount {
 model AuthSession {
   id           String    @id @default(uuid()) @db.Uuid
   sessionToken String    @unique
-  userId       String
+  userId       String    @db.Uuid
   expires      DateTime
   user         AuthUser @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## Summary
- specify `@db.Uuid` for `userId` in auth account and session models
- add migration to convert `userId` columns to UUID and restore foreign keys

## Testing
- `npx prisma migrate dev --name fix-auth-userid-type` *(fails: Can't reach database server)*
- `bun prisma:migrate` *(fails: prisma: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a737ab0fe0832a9853a1c4a79a4b6a