### PR TITLE
fix: quote foreign keys for Unit and ServiceLog

### DIFF
--- a/_/apps/web/src/app/api/migrations/001_create_consumable_tables.sql
+++ b/_/apps/web/src/app/api/migrations/001_create_consumable_tables.sql
@@ -7,9 +7,9 @@ CREATE TABLE IF NOT EXISTS consumable_items (
 
 CREATE TABLE IF NOT EXISTS unit_consumables (
   id SERIAL PRIMARY KEY,
-  unit_id INTEGER NOT NULL REFERENCES units(id) ON DELETE CASCADE,
+  unit_id INTEGER NOT NULL REFERENCES "public"."Unit"("id") ON DELETE CASCADE,
   consumable_id INTEGER NOT NULL REFERENCES consumable_items(id),
-  service_log_id INTEGER REFERENCES service_logs(id) ON DELETE CASCADE,
+  service_log_id INTEGER REFERENCES "public"."ServiceLog"("id") ON DELETE CASCADE,
   quantity INTEGER NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- quote `unit_consumables` foreign keys to reference `"public"."Unit"` and `"public"."ServiceLog"`
- keep cascaded deletes and `id` references consistent with Prisma schema

## Testing
- `sudo -u postgres psql testdb < _/apps/web/src/app/api/migrations/001_create_consumable_tables.sql`
- `sudo -u postgres psql testdb -c "\d unit_consumables"`
- `cd _/apps/web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73bb901f4832a8108b804c3324440