### PR TITLE
Load env vars in Vite config

### DIFF
--- a/_/apps/web/.env.example
+++ b/_/apps/web/.env.example
@@ -1,4 +1,6 @@
 # Example environment variables for the web app
 # DATABASE_URL should point to your PostgreSQL instance
+## Example using a Neon serverless Postgres instance:
+# DATABASE_URL=postgresql://neondb_owner:npg_WONhw6ZV5XgH@ep-soft-violet-a168edqt-pooler.ap-southeast-1.aws.neon.tech/asset_management?sslmode=require&channel_binding=require
 DATABASE_URL=postgres://user:password@localhost:5432/asset_management
 AUTH_SECRET=your-auth-secret

--- a/_/apps/web/vite.config.ts
+++ b/_/apps/web/vite.config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { reactRouter } from '@react-router/dev/vite';
 import { reactRouterHonoServer } from 'react-router-hono-server/dev';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import babel from 'vite-plugin-babel';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { addRenderIds } from './plugins/addRenderIds';
@@ -12,6 +12,10 @@ import { loadFontsFromTailwindSource } from './plugins/loadFontsFromTailwindSour
 import { nextPublicProcessEnv } from './plugins/nextPublicProcessEnv';
 import { restart } from './plugins/restart';
 import { restartEnvFileChange } from './plugins/restartEnvFileChange';
+
+// Load environment variables from the nearest .env file before using them
+const env = loadEnv(process.env.NODE_ENV || 'development', process.cwd(), '');
+Object.assign(process.env, env);
 
 // Ensure a database connection string is configured before starting the server.
 if (!process.env.DATABASE_URL) {


### PR DESCRIPTION
## Summary
- load environment variables in Vite config before verifying `DATABASE_URL`
- document example Neon `DATABASE_URL` in web app `.env.example`

## Testing
- `bun run lint`
- `bun run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a742453058832a9223dab1dd542d66