### PR TITLE
fix(web): set auth env variables

### DIFF
--- a/_/apps/web/.env
+++ b/_/apps/web/.env
@@ -2,4 +2,5 @@ DATABASE_URL="postgresql://neondb_owner:npg_WONhw6ZV5XgH@ep-soft-violet-a168edqt
 # DATABASE_URL=postgres://user:password@localhost:5432/asset_management
 # DATABASE_URL="postgresql://neondb_owner:npg_1PrH2piuqwka@ep-raspy-star-aelz9x5r.c-2.us-east-2.aws.neon.tech/neondb?sslmode=require"
 NEXT_PUBLIC_CREATE_BASE_URL=http://localhost:4000
-AUTH_SECRET=your-auth-secret
+AUTH_SECRET=52831d5f2990efb56a0e15ba86f801719c6bf83b0ba4dbb8e240039560810eb1
+AUTH_URL=http://localhost:4000


### PR DESCRIPTION
## Summary
- set web app AUTH_SECRET and AUTH_URL in `.env`

## Testing
- `bun run lint`
- `curl -i http://localhost:4000/api/auth/session`


------
https://chatgpt.com/codex/tasks/task_e_68a749b20220832ab417e64383759e78