### PR TITLE
chore: exclude session endpoint from auth actions

### DIFF
--- a/_/apps/web/__create/is-auth-action.ts
+++ b/_/apps/web/__create/is-auth-action.ts
@@ -1,6 +1,5 @@
 const authActions = [
     "providers",
-    "session",
     "csrf",
     "signin",
     "signout",


### PR DESCRIPTION
## Summary
- remove `session` from auth action list so `/api/auth/session` hits its own route

## Testing
- `curl -i http://localhost:4001/api/auth/session`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7497d31b0832a88ab0032b63e49e3