### PR TITLE
feat(web): configure auth base path

### DIFF
--- a/_/apps/web/__create/index.ts
+++ b/_/apps/web/__create/index.ts
@@ -85,6 +85,7 @@ app.use(
     '*',
     initAuthConfig((c) => ({
       secret: c.env.AUTH_SECRET,
+      basePath: '/api/auth',
       pages: {
         signIn: '/account/signin',
         signOut: '/account/logout',


### PR DESCRIPTION
## Summary
- set Auth.js base path to `/api/auth`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74b944d9c832a92d960a5cd41d73d