### PR TITLE
Improve unit fetch error handling

### DIFF
--- a/_/apps/web/src/app/page.jsx
+++ b/_/apps/web/src/app/page.jsx
@@ -48,10 +48,22 @@ function HomePage() {
       const url = new URL("/api/units", window.location.origin);
       if (searchTerm) url.searchParams.set("search", searchTerm);
 
-      const response = await fetch(url);
+      const response = await fetch(url, {
+        headers: { Accept: "application/json" },
+      });
       if (!response.ok) {
+        const contentType = response.headers.get("content-type");
+        if (contentType && contentType.includes("application/json")) {
+          const errorData = await response.json();
+          throw new Error(
+            errorData.error ||
+              `Failed to fetch units: ${response.status} ${response.statusText}`
+          );
+        }
+        const errorText = await response.text();
         throw new Error(
-          `Failed to fetch units: ${response.status} ${response.statusText}`
+          errorText ||
+            `Failed to fetch units: ${response.status} ${response.statusText}`
         );
       }
       return response.json();

--- a/_/apps/web/src/app/units/page.jsx
+++ b/_/apps/web/src/app/units/page.jsx
@@ -54,9 +54,17 @@ function UnitsPageContent() {
         params.append("search", searchTerm);
       }
 
-      const response = await fetch(`/api/units?${params}`);
+      const response = await fetch(`/api/units?${params}`, {
+        headers: { Accept: "application/json" },
+      });
       if (!response.ok) {
-        throw new Error("Failed to fetch units");
+        const contentType = response.headers.get("content-type");
+        if (contentType && contentType.includes("application/json")) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || "Failed to fetch units");
+        }
+        const errorText = await response.text();
+        throw new Error(errorText || "Failed to fetch units");
       }
       return response.json();
     },
@@ -66,10 +74,16 @@ function UnitsPageContent() {
     mutationFn: async (unitId) => {
       const response = await fetch(`/api/units/${unitId}`, {
         method: "DELETE",
+        headers: { Accept: "application/json" },
       });
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to delete unit");
+        const contentType = response.headers.get("content-type");
+        if (contentType && contentType.includes("application/json")) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || "Failed to delete unit");
+        }
+        const errorText = await response.text();
+        throw new Error(errorText || "Failed to delete unit");
       }
       return response.json();
     },


### PR DESCRIPTION
## Summary
- add `Accept: application/json` header to unit fetch calls
- handle non-JSON error responses using `content-type` checks

## Testing
- `npm test` *(fails: vitest not found)*
- `node - <<'NODE' ...` units page error handling simulation
- `node - <<'NODE' ...` root page error handling simulation

------
https://chatgpt.com/codex/tasks/task_e_68a7564a1c80832a81c306cce6b024c5