### PR TITLE
feat(web): add redis configuration and prisma cache

### DIFF
--- a/_/apps/web/.env
+++ b/_/apps/web/.env
@@ -4,3 +4,4 @@ DATABASE_URL="postgresql://neondb_owner:npg_WONhw6ZV5XgH@ep-soft-violet-a168edqt
 NEXT_PUBLIC_CREATE_BASE_URL=http://localhost:4000
 AUTH_SECRET=52831d5f2990efb56a0e15ba86f801719c6bf83b0ba4dbb8e240039560810eb1
 AUTH_URL=http://localhost:4000
+REDIS_URL=redis://user:pass@localhost:6379

--- a/_/apps/web/.env.example
+++ b/_/apps/web/.env.example
@@ -4,3 +4,4 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/asset_management
 AUTH_SECRET=your-auth-secret
 NEXT_PUBLIC_CREATE_BASE_URL=http://localhost:4000
+REDIS_URL=redis://user:pass@localhost:6379

--- a/_/apps/web/bun.lock
+++ b/_/apps/web/bun.lock
@@ -38,6 +38,7 @@
         "motion": "^12.7.4",
         "papaparse": "^5.5.2",
         "pdfjs-dist": "3.11.174",
+        "prisma-redis-middleware": "^4.8.0",
         "react": "^18.2.0",
         "react-colorful": "^5.6.1",
         "react-day-picker": "^9.6.7",
@@ -952,6 +953,8 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "async-cache-dedupe": ["async-cache-dedupe@1.12.0", "", { "dependencies": { "mnemonist": "^0.39.2", "safe-stable-stringify": "^2.3.1" } }, "sha512-LKumaBNhzvZrbrRi3DtIf0ETgjqcGOa/M2U+0DpTp8f+RzIiWubiQmBjuYUaihxetR3cWWC6hQj/uDVBuYajRA=="],
+
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
     "autoprefixer": ["autoprefixer@10.4.21", "", { "dependencies": { "browserslist": "^4.24.4", "caniuse-lite": "^1.0.30001702", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ=="],
@@ -1632,6 +1635,8 @@
 
     "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
+    "mnemonist": ["mnemonist@0.39.8", "", { "dependencies": { "obliterator": "^2.0.1" } }, "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ=="],
+
     "morgan": ["morgan@1.10.0", "", { "dependencies": { "basic-auth": "~2.0.1", "debug": "2.6.9", "depd": "~2.0.0", "on-finished": "~2.3.0", "on-headers": "~1.0.2" } }, "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ=="],
 
     "motion": ["motion@12.12.2", "", { "dependencies": { "framer-motion": "^12.12.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-ZMvJXkm8QnEYH8NsKGNGMkROjyMtouc7FxTB7FVXW5KQk+ZhunEkh0FWdUKT9kia8dGL0o6YU/RmrFxsI5Plgw=="],
@@ -1703,6 +1708,8 @@
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "obliterator": ["obliterator@2.0.5", "", {}, "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw=="],
 
     "obuf": ["obuf@1.1.2", "", {}, "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="],
 
@@ -1824,6 +1831,8 @@
 
     "prisma": ["prisma@6.14.0", "", { "dependencies": { "@prisma/config": "6.14.0", "@prisma/engines": "6.14.0" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-QEuCwxu+Uq9BffFw7in8In+WfbSUN0ewnaSUKloLkbJd42w6EyFckux4M0f7VwwHlM3A8ssaz4OyniCXlsn0WA=="],
 
+    "prisma-redis-middleware": ["prisma-redis-middleware@4.8.0", "", { "dependencies": { "async-cache-dedupe": "1.12.0", "ioredis": "5.3.2" } }, "sha512-d1B7TVLiR8aSiOY2GPKKDb5EWGTK+EmlIkztAZCPWxs4/IHGfIAZiDoLklp6CcK+5ckjcaJq8aWE5AjRJ3+Rpg=="],
+
     "proc-log": ["proc-log@3.0.0", "", {}, "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A=="],
 
     "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
@@ -1935,6 +1944,8 @@
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -2409,6 +2420,8 @@
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "prisma-redis-middleware/ioredis": ["ioredis@5.3.2", "", { "dependencies": { "@ioredis/commands": "^1.1.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/_/apps/web/package.json
+++ b/_/apps/web/package.json
@@ -50,6 +50,7 @@
 		"motion": "^12.7.4",
 		"papaparse": "^5.5.2",
 		"pdfjs-dist": "3.11.174",
+		"prisma-redis-middleware": "^4.8.0",
 		"react": "^18.2.0",
 		"react-colorful": "^5.6.1",
 		"react-day-picker": "^9.6.7",

--- a/_/apps/web/src/app/api/utils/prisma.js
+++ b/_/apps/web/src/app/api/utils/prisma.js
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client';
+import Redis from 'ioredis';
+import { createPrismaRedisCache } from 'prisma-redis-middleware';
+
+const prisma = new PrismaClient();
+const redis = new Redis(process.env.REDIS_URL);
+
+prisma.$use(
+  createPrismaRedisCache({
+    storage: { type: 'redis', options: { client: redis } },
+    cacheTime: 300,
+  }),
+);
+
+export default prisma;

--- a/_/apps/web/src/jobs/reminderQueue.js
+++ b/_/apps/web/src/jobs/reminderQueue.js
@@ -13,7 +13,7 @@ async function initQueue() {
   }
 
   try {
-    const connection = new Redis(url);
+    const connection = new Redis(url, { maxRetriesPerRequest: null });
     await connection.ping();
     reminderQueue = new Queue("reminders", { connection });
   } catch (err) {

--- a/_/apps/web/src/jobs/reminderWorker.js
+++ b/_/apps/web/src/jobs/reminderWorker.js
@@ -14,7 +14,7 @@ async function initWorker() {
   }
 
   try {
-    const connection = new Redis(url);
+    const connection = new Redis(url, { maxRetriesPerRequest: null });
     await connection.ping();
     reminderWorker = new Worker(
       "reminders",


### PR DESCRIPTION
## Summary
- add `REDIS_URL` environment variable for Redis
- integrate Prisma with Redis cache middleware
- configure BullMQ jobs to connect to Redis reliably

## Testing
- `redis-cli -u redis://user:pass@localhost:6379 ping`
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68a75740cdb0832aa7cb48437b855518