### PR TITLE
Handle non-JSON responses in units queries

### DIFF
--- a/_/apps/web/src/app/page.jsx
+++ b/_/apps/web/src/app/page.jsx
@@ -51,22 +51,23 @@ function HomePage() {
       const response = await fetch(url, {
         headers: { Accept: "application/json" },
       });
-      if (!response.ok) {
-        const contentType = response.headers.get("content-type");
-        if (contentType && contentType.includes("application/json")) {
-          const errorData = await response.json();
-          throw new Error(
-            errorData.error ||
-              `Failed to fetch units: ${response.status} ${response.statusText}`
-          );
-        }
+      const contentType = response.headers.get("content-type");
+      if (!contentType || !contentType.includes("application/json")) {
         const errorText = await response.text();
         throw new Error(
           errorText ||
+            `Unexpected response format: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(
+          data.error ||
             `Failed to fetch units: ${response.status} ${response.statusText}`
         );
       }
-      return response.json();
+      return data;
     },
   });
 

--- a/_/apps/web/src/app/units/page.jsx
+++ b/_/apps/web/src/app/units/page.jsx
@@ -57,16 +57,23 @@ function UnitsPageContent() {
       const response = await fetch(`/api/units?${params}`, {
         headers: { Accept: "application/json" },
       });
-      if (!response.ok) {
-        const contentType = response.headers.get("content-type");
-        if (contentType && contentType.includes("application/json")) {
-          const errorData = await response.json();
-          throw new Error(errorData.error || "Failed to fetch units");
-        }
+      const contentType = response.headers.get("content-type");
+      if (!contentType || !contentType.includes("application/json")) {
         const errorText = await response.text();
-        throw new Error(errorText || "Failed to fetch units");
+        throw new Error(
+          errorText ||
+            `Unexpected response format: ${response.status} ${response.statusText}`
+        );
       }
-      return response.json();
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(
+          data.error ||
+            `Failed to fetch units: ${response.status} ${response.statusText}`
+        );
+      }
+      return data;
     },
   });
 


### PR DESCRIPTION
## Summary
- Guard `HomePage` and `UnitsPage` queries against non-JSON responses
- Throw informative errors using response text when content type is unexpected

## Testing
- `npm run lint`
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a760fe9ce0832ab6ecf25643ffa3a7