### PR TITLE
Add IDs to unit search inputs for better autofill

### DIFF
--- a/_/apps/web/src/app/page.jsx
+++ b/_/apps/web/src/app/page.jsx
@@ -235,6 +235,8 @@ function HomePage() {
             <div className="relative flex-1 max-w-md">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
+                id="unit-search-home"
+                name="search"
                 type="text"
                 placeholder="Search units by name, model, serial number..."
                 value={searchTerm}

--- a/_/apps/web/src/app/units/page.jsx
+++ b/_/apps/web/src/app/units/page.jsx
@@ -192,6 +192,8 @@ function UnitsPageContent() {
             <div className="relative max-w-md">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
+                id="unit-search"
+                name="search"
                 type="text"
                 placeholder="Search units by name, model, serial number..."
                 className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"


### PR DESCRIPTION
## Summary
- add explicit `id`/`name` attributes to home page unit search
- add `id`/`name` to units page search input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76105b66c832abd64615a054320dd