### PR TITLE
chore: configure local redis

### DIFF
--- a/_/apps/web/.env
+++ b/_/apps/web/.env
@@ -4,5 +4,5 @@ DATABASE_URL="postgresql://neondb_owner:npg_WONhw6ZV5XgH@ep-soft-violet-a168edqt
 NEXT_PUBLIC_CREATE_BASE_URL=http://localhost:4000
 AUTH_SECRET=52831d5f2990efb56a0e15ba86f801719c6bf83b0ba4dbb8e240039560810eb1
 AUTH_URL=http://localhost:4000
-REDIS_URL=redis://default:mArbxdlVrQo0pSRbNjCtECNdHSYI2WPO@redis-12327.c1.ap-southeast-1-1.ec2.redns.redis-cloud.com:12327
+REDIS_URL=redis://127.0.0.1:6379
 # REDIS_URL=redis://user:pass@localhost:6379

--- a/_/apps/web/src/app/api/utils/prisma.js
+++ b/_/apps/web/src/app/api/utils/prisma.js
@@ -7,15 +7,21 @@ const prisma = new PrismaClient();
 const url = process.env.REDIS_URL;
 if (url) {
   const redis = new Redis(url);
-  redis.on("error", (err) => {
-    console.warn("Redis connection error; disabling cache", err);
-  });
-  prisma.$use(
-    createPrismaRedisCache({
-      storage: { type: "redis", options: { client: redis } },
-      cacheTime: 300,
-    }),
-  );
+  try {
+    await redis.ping();
+    redis.on("error", (err) => {
+      console.warn("Redis connection error; disabling cache", err);
+    });
+    prisma.$use(
+      createPrismaRedisCache({
+        storage: { type: "redis", options: { client: redis } },
+        cacheTime: 300,
+      }),
+    );
+  } catch (err) {
+    console.warn("Unable to connect to Redis; Redis cache disabled", err);
+    redis.disconnect();
+  }
 } else {
   console.warn("REDIS_URL not set; Redis cache disabled");
 }


### PR DESCRIPTION
## Summary
- point web app to local Redis instance
- handle Redis connection failures gracefully

## Testing
- `bun run lint`
- `bun run test`
- `bun run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a7685cbd18832abb51e9b2c3017f2f