### PR TITLE
Handle non-JSON responses when loading units

### DIFF
--- a/_/apps/web/src/app/page.jsx
+++ b/_/apps/web/src/app/page.jsx
@@ -55,8 +55,9 @@ function HomePage() {
       if (!contentType || !contentType.includes("application/json")) {
         const errorText = await response.text();
         throw new Error(
-          errorText ||
-            `Unexpected response format: ${response.status} ${response.statusText}`
+          !response.ok && errorText && !errorText.trim().startsWith("<")
+            ? errorText
+            : `Failed to fetch units: ${response.status} ${response.statusText}`
         );
       }
 

--- a/_/apps/web/src/app/units/page.jsx
+++ b/_/apps/web/src/app/units/page.jsx
@@ -61,8 +61,9 @@ function UnitsPageContent() {
       if (!contentType || !contentType.includes("application/json")) {
         const errorText = await response.text();
         throw new Error(
-          errorText ||
-            `Unexpected response format: ${response.status} ${response.statusText}`
+          !response.ok && errorText && !errorText.trim().startsWith("<")
+            ? errorText
+            : `Failed to fetch units: ${response.status} ${response.statusText}`
         );
       }
 


### PR DESCRIPTION
## Summary
- Improve units list and home page fetch logic to surface meaningful errors when API returns non-JSON content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7720b0f0c832aab18be2fecb8270e