### PR TITLE
feat: validate database and redis connections

### DIFF
--- a/_/apps/web/src/app/api/utils/prisma.js
+++ b/_/apps/web/src/app/api/utils/prisma.js
@@ -4,26 +4,34 @@ import { createPrismaRedisCache } from "prisma-redis-middleware";
 
 const prisma = new PrismaClient();
 
-const url = process.env.REDIS_URL;
-if (url) {
-  const redis = new Redis(url);
+(async () => {
   try {
-    await redis.ping();
-    redis.on("error", (err) => {
-      console.warn("Redis connection error; disabling cache", err);
-    });
-    prisma.$use(
-      createPrismaRedisCache({
-        storage: { type: "redis", options: { client: redis } },
-        cacheTime: 300,
-      }),
-    );
+    await prisma.$connect();
   } catch (err) {
-    console.warn("Unable to connect to Redis; Redis cache disabled", err);
-    redis.disconnect();
+    console.warn("Unable to connect to the database", err);
   }
-} else {
-  console.warn("REDIS_URL not set; Redis cache disabled");
-}
+
+  const url = process.env.REDIS_URL;
+  if (url) {
+    const redis = new Redis(url);
+    try {
+      await redis.ping();
+      redis.on("error", (err) => {
+        console.warn("Redis connection error; disabling cache", err);
+      });
+      prisma.$use(
+        createPrismaRedisCache({
+          storage: { type: "redis", options: { client: redis } },
+          cacheTime: 300,
+        }),
+      );
+    } catch (err) {
+      console.warn("Unable to connect to Redis; Redis cache disabled", err);
+      redis.disconnect();
+    }
+  } else {
+    console.warn("REDIS_URL not set; Redis cache disabled");
+  }
+})();
 
 export default prisma;


### PR DESCRIPTION
## Summary
- ensure Prisma checks database connectivity at startup
- guard Redis cache setup with connection validation

## Testing
- `bun test` *(fails: Cannot find module '@hono/auth-js/react', Cannot find package 'zod')*

------
https://chatgpt.com/codex/tasks/task_e_68a773816dd8832aacadcb8c436b6d4d