### PR TITLE
feat: validate database and redis connections

### DIFF
--- a/_/apps/web/src/app/api/utils/prisma.js
+++ b/_/apps/web/src/app/api/utils/prisma.js
@@ -3,15 +3,29 @@ import Redis from "ioredis";
 import { createPrismaRedisCache } from "prisma-redis-middleware";
 
 const prisma = new PrismaClient();
+let redis;
 
-const url = process.env.REDIS_URL;
-if (url) {
-  const redis = new Redis(url);
+(async () => {
+  try {
+    await prisma.$connect();
+  } catch (err) {
+    console.warn("Unable to connect to the database", err);
+    return;
+  }
+
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    console.warn("REDIS_URL not set; Redis cache disabled");
+    return;
+  }
+
+  redis = new Redis(url);
+  redis.on("error", (err) => {
+    console.warn("Redis connection error; disabling cache", err);
+  });
+
   try {
     await redis.ping();
-    redis.on("error", (err) => {
-      console.warn("Redis connection error; disabling cache", err);
-    });
     prisma.$use(
       createPrismaRedisCache({
         storage: { type: "redis", options: { client: redis } },
@@ -21,9 +35,13 @@ if (url) {
   } catch (err) {
     console.warn("Unable to connect to Redis; Redis cache disabled", err);
     redis.disconnect();
+    redis = undefined;
   }
-} else {
-  console.warn("REDIS_URL not set; Redis cache disabled");
-}
+})();
+
+process.on("beforeExit", async () => {
+  await prisma.$disconnect();
+  redis?.disconnect();
+});
 
 export default prisma;


### PR DESCRIPTION
## Summary
- ensure Prisma checks database connectivity at startup
- guard Redis cache setup with connection validation and cleanup on exit

## Testing
- `bun test` *(fails: Cannot find module '@auth/create' from '/workspace/asset_management_ver3/_/apps/web/src/auth.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a773816dd8832aacadcb8c436b6d4d