### PR TITLE
Handle conditional query parameters and validate JSON responses

### DIFF
--- a/_/apps/web/src/app/page.jsx
+++ b/_/apps/web/src/app/page.jsx
@@ -45,19 +45,23 @@ function HomePage() {
   } = useQuery({
     queryKey: ["units", searchTerm],
     queryFn: async () => {
-      const url = new URL("/api/units", window.location.origin);
-      if (searchTerm) url.searchParams.set("search", searchTerm);
+      const params = new URLSearchParams();
+      if (searchTerm) {
+        params.append("search", searchTerm);
+      }
+      const query = params.toString();
 
-      const response = await fetch(url, {
+      const response = await fetch(`/api/units${query ? `?${query}` : ""}`, {
         headers: { Accept: "application/json" },
       });
+
       const contentType = response.headers.get("content-type");
       if (!contentType || !contentType.includes("application/json")) {
         const errorText = await response.text();
         throw new Error(
           !response.ok && errorText && !errorText.trim().startsWith("<")
             ? errorText
-            : `Failed to fetch units: ${response.status} ${response.statusText}`
+            : `Expected application/json response, got ${contentType || "unknown"}`
         );
       }
 

--- a/_/apps/web/src/app/units/page.jsx
+++ b/_/apps/web/src/app/units/page.jsx
@@ -53,17 +53,19 @@ function UnitsPageContent() {
       if (searchTerm) {
         params.append("search", searchTerm);
       }
+      const query = params.toString();
 
-      const response = await fetch(`/api/units?${params}`, {
+      const response = await fetch(`/api/units${query ? `?${query}` : ""}`, {
         headers: { Accept: "application/json" },
       });
+
       const contentType = response.headers.get("content-type");
       if (!contentType || !contentType.includes("application/json")) {
         const errorText = await response.text();
         throw new Error(
           !response.ok && errorText && !errorText.trim().startsWith("<")
             ? errorText
-            : `Failed to fetch units: ${response.status} ${response.statusText}`
+            : `Expected application/json response, got ${contentType || "unknown"}`
         );
       }
 


### PR DESCRIPTION
## Summary
- Build unit list API URLs only when query parameters exist
- Enforce JSON response validation with clearer error messages in Units and Home pages

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a778cee958832abcf61a1034c538c6