### PR TITLE
feat(web): add reusable units hook

### DIFF
--- a/_/apps/web/src/app/page.jsx
+++ b/_/apps/web/src/app/page.jsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import {
-  useQuery,
-  QueryClient,
-  QueryClientProvider,
-} from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   Search,
   Plus,
@@ -20,6 +16,7 @@ import {
   Info,
 } from "lucide-react";
 import useUser from "@/utils/useUser";
+import useUnits from "@/utils/useUnits";
 import Header from "@/components/Header";
 
 // Create a stable query client
@@ -38,39 +35,7 @@ function HomePage() {
   const [searchTerm, setSearchTerm] = useState("");
   const { data: currentUser, loading: userLoading } = useUser();
 
-  const {
-    data: unitsData,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["units", searchTerm],
-    queryFn: async () => {
-      const url = new URL("/api/units", window.location.origin);
-      if (searchTerm) url.searchParams.set("search", searchTerm);
-
-      const response = await fetch(url, {
-        headers: { Accept: "application/json" },
-      });
-      const contentType = response.headers.get("content-type");
-      if (!contentType || !contentType.includes("application/json")) {
-        const errorText = await response.text();
-        throw new Error(
-          !response.ok && errorText && !errorText.trim().startsWith("<")
-            ? errorText
-            : `Failed to fetch units: ${response.status} ${response.statusText}`
-        );
-      }
-
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(
-          data.error ||
-            `Failed to fetch units: ${response.status} ${response.statusText}`
-        );
-      }
-      return data;
-    },
-  });
+  const { data: unitsData, isLoading, error } = useUnits(searchTerm);
 
   const units = unitsData?.units || [];
 

--- a/_/apps/web/src/app/units/page.jsx
+++ b/_/apps/web/src/app/units/page.jsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import {
-  useQuery,
   useMutation,
   useQueryClient,
   QueryClient,
@@ -23,6 +22,7 @@ import {
   Wrench,
 } from "lucide-react";
 import useUser from "@/utils/useUser";
+import useUnits from "@/utils/useUnits";
 import Header from "@/components/Header";
 
 // Create a stable query client
@@ -42,41 +42,7 @@ function UnitsPageContent() {
   const { data: currentUser } = useUser();
   const queryClient = useQueryClient();
 
-  const {
-    data: unitsData,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["units", searchTerm],
-    queryFn: async () => {
-      const params = new URLSearchParams();
-      if (searchTerm) {
-        params.append("search", searchTerm);
-      }
-
-      const response = await fetch(`/api/units?${params}`, {
-        headers: { Accept: "application/json" },
-      });
-      const contentType = response.headers.get("content-type");
-      if (!contentType || !contentType.includes("application/json")) {
-        const errorText = await response.text();
-        throw new Error(
-          !response.ok && errorText && !errorText.trim().startsWith("<")
-            ? errorText
-            : `Failed to fetch units: ${response.status} ${response.statusText}`
-        );
-      }
-
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(
-          data.error ||
-            `Failed to fetch units: ${response.status} ${response.statusText}`
-        );
-      }
-      return data;
-    },
-  });
+  const { data: unitsData, isLoading, error } = useUnits(searchTerm);
 
   const deleteUnitMutation = useMutation({
     mutationFn: async (unitId) => {

--- a/_/apps/web/src/utils/useUnits.test.ts
+++ b/_/apps/web/src/utils/useUnits.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import useUnits from "./useUnits";
+
+const createWrapper = () => {
+  const queryClient = new QueryClient();
+  // eslint-disable-next-line react/display-name
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("useUnits", () => {
+  it("fetches units successfully", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: async () => ({ units: [{ id: 1 }] }),
+    } as any);
+
+    const { result } = renderHook(() => useUnits(""), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ units: [{ id: 1 }] });
+    });
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it("handles fetch error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      headers: { get: () => "application/json" },
+      json: async () => ({ error: "Failed" }),
+      status: 500,
+      statusText: "Server Error",
+    } as any);
+
+    const { result } = renderHook(() => useUnits(""), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/_/apps/web/src/utils/useUnits.ts
+++ b/_/apps/web/src/utils/useUnits.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface UnitsResponse {
+  units: any[];
+  [key: string]: any;
+}
+
+const fetchUnits = async (searchTerm: string): Promise<UnitsResponse> => {
+  const url = new URL("/api/units", window.location.origin);
+  if (searchTerm) url.searchParams.set("search", searchTerm);
+
+  const response = await fetch(url.toString(), {
+    headers: { Accept: "application/json" },
+  });
+  const contentType = response.headers.get("content-type");
+  if (!contentType || !contentType.includes("application/json")) {
+    const errorText = await response.text();
+    throw new Error(
+      !response.ok && errorText && !errorText.trim().startsWith("<")
+        ? errorText
+        : `Failed to fetch units: ${response.status} ${response.statusText}`
+    );
+  }
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      data.error ||
+        `Failed to fetch units: ${response.status} ${response.statusText}`
+    );
+  }
+  return data;
+};
+
+export function useUnits(searchTerm = "") {
+  return useQuery({
+    queryKey: ["units", searchTerm],
+    queryFn: () => fetchUnits(searchTerm),
+  });
+}
+
+export default useUnits;


### PR DESCRIPTION
## Summary
- add `useUnits` hook centralizing units fetch with error handling
- refactor home and units pages to consume `useUnits`
- cover hook with Vitest ensuring success and error cases

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest @testing-library/react @testing-library/jest-dom @tanstack/react-query react react-dom --no-save` *(installation did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a778fd9124832a8e71b5fd72164275