### PR TITLE
Handle non-JSON unit fetch responses

### DIFF
--- a/_/apps/web/src/utils/useUnits.test.tsx
+++ b/_/apps/web/src/utils/useUnits.test.tsx
@@ -4,7 +4,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import useUnits from "./useUnits";
 
 const createWrapper = () => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
   // eslint-disable-next-line react/display-name
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -48,6 +52,24 @@ describe("useUnits", () => {
 
     await waitFor(() => {
       expect(result.current.error).toBeDefined();
+    });
+  });
+
+  it("throws auth error when HTML is returned", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      text: async () => "<html>Signin</html>",
+    } as any);
+
+    const { result } = renderHook(() => useUnits(""), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe(
+        "Unauthorized – redirecting to sign-in"
+      );
     });
   });
 });

--- a/_/apps/web/src/utils/useUnits.ts
+++ b/_/apps/web/src/utils/useUnits.ts
@@ -11,23 +11,46 @@ const fetchUnits = async (searchTerm: string): Promise<UnitsResponse> => {
 
   const response = await fetch(url.toString(), {
     headers: { Accept: "application/json" },
+    credentials: "include",
   });
+
   const contentType = response.headers.get("content-type");
+  let data: UnitsResponse;
+
   if (!contentType || !contentType.includes("application/json")) {
-    const errorText = await response.text();
-    throw new Error(
-      !response.ok && errorText && !errorText.trim().startsWith("<")
-        ? errorText
-        : `Failed to fetch units: ${response.status} ${response.statusText}`
-    );
+    const text = await response.text();
+    const lower = text.toLowerCase();
+
+    if (
+      text.trim().startsWith("<") ||
+      lower.includes("signin") ||
+      lower.includes("sign-in") ||
+      lower.includes("login") ||
+      lower.includes("unauth")
+    ) {
+      throw new Error("Unauthorized – redirecting to sign-in");
+    }
+
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error(
+        !response.ok && text
+          ? text
+          : `Failed to fetch units: ${response.status} ${response.statusText}`
+      );
+    }
+  } else {
+    data = await response.json();
   }
-  const data = await response.json();
+
   if (!response.ok) {
     throw new Error(
       data.error ||
         `Failed to fetch units: ${response.status} ${response.statusText}`
     );
   }
+
   return data;
 };
 


### PR DESCRIPTION
## Summary
- read unit API responses as text when Content-Type is missing or not JSON
- detect HTML or auth-related text and throw an auth redirect error
- ensure hooks tests cover HTML unauthorised responses

## Testing
- `npm test` *(fails: test/getSessionHtmlResponse.test.ts > getSession > returns null when response is not JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68a77d277ec4832abd42bed6d3a80e6a