### PR TITLE
Ensure units API returns JSON and add auth tests

### DIFF
--- a/_/apps/web/src/app/api/[...notfound]/route.js
+++ b/_/apps/web/src/app/api/[...notfound]/route.js
@@ -1,0 +1,17 @@
+const handler = () =>
+  Response.json(
+    { error: "Not Found" },
+    {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+
+export {
+  handler as GET,
+  handler as POST,
+  handler as PUT,
+  handler as DELETE,
+  handler as PATCH,
+  handler as OPTIONS,
+};

--- a/_/apps/web/src/app/api/units/route.js
+++ b/_/apps/web/src/app/api/units/route.js
@@ -24,7 +24,10 @@ export async function GET(request) {
     if (!parseResult.success) {
       return Response.json(
         { error: "Invalid query parameters", details: parseResult.error.flatten() },
-        { status: 400 },
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -66,10 +69,19 @@ export async function GET(request) {
 
     const units = await sql(query, params);
 
-    return Response.json({ units });
+    return Response.json(
+      { units },
+      { headers: { "Content-Type": "application/json" } },
+    );
   } catch (error) {
     console.error("Error fetching units:", error);
-    return Response.json({ error: "Failed to fetch units" }, { status: 500 });
+    return Response.json(
+      { error: "Failed to fetch units" },
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 }
 
@@ -115,7 +127,10 @@ export async function POST(request) {
     if (!body.success) {
       return Response.json(
         { error: "Invalid input", details: body.error.flatten() },
-        { status: 400 },
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
       );
     }
     const data = body.data;
@@ -174,7 +189,10 @@ export async function POST(request) {
       ],
     );
 
-    return Response.json({ unit: result[0] });
+    return Response.json(
+      { unit: result[0] },
+      { headers: { "Content-Type": "application/json" } },
+    );
   } catch (error) {
     console.error("Error creating unit:", error);
     return Response.json(
@@ -182,7 +200,10 @@ export async function POST(request) {
         error: "Failed to create unit",
         details: error.message,
       },
-      { status: 500 },
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
     );
   }
 }

--- a/_/apps/web/src/app/api/units/route.test.js
+++ b/_/apps/web/src/app/api/units/route.test.js
@@ -1,32 +1,72 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, POST } from './route.js';
 
+let lastRequest;
 vi.mock('../utils/auth-middleware', () => ({
-  requireRole: vi.fn().mockResolvedValue({ user: { role: 'admin' } })
+  requireRole: vi.fn(() => {
+    const cookie = lastRequest?.headers.get('cookie');
+    if (cookie === 'session=valid') {
+      return { user: { role: 'admin' } };
+    }
+    return Response.json(
+      { error: 'Unauthorized' },
+      { status: 401, headers: { 'Content-Type': 'application/json' } },
+    );
+  }),
 }));
 
 vi.mock('../utils/sql', () => ({
-  default: vi.fn().mockResolvedValue([])
+  default: vi.fn().mockResolvedValue([]),
 }));
 
 describe('Units API route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lastRequest = undefined;
+  });
+
+  it('returns 401 without session cookie', async () => {
+    const req = new Request('http://localhost/api/units');
+    lastRequest = req;
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns units when authorized', async () => {
+    const req = new Request('http://localhost/api/units', {
+      headers: { cookie: 'session=valid' },
+    });
+    lastRequest = req;
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    const body = await res.json();
+    expect(body).toHaveProperty('units');
   });
 
   it('returns 400 for invalid sortBy', async () => {
-    const req = new Request('http://localhost/api/units?sortBy=invalid');
+    const req = new Request('http://localhost/api/units?sortBy=invalid', {
+      headers: { cookie: 'session=valid' },
+    });
+    lastRequest = req;
     const res = await GET(req);
     expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toBe('application/json');
   });
 
   it('returns 400 for invalid body', async () => {
     const req = new Request('http://localhost/api/units', {
       method: 'POST',
-      body: JSON.stringify({})
+      body: JSON.stringify({}),
+      headers: { cookie: 'session=valid' },
     });
+    lastRequest = req;
     const res = await POST(req);
     expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toBe('application/json');
   });
 
   it('keeps falsy values when provided', async () => {
@@ -36,12 +76,12 @@ describe('Units API route', () => {
       body: JSON.stringify({
         unit_name: 'Test Unit',
         serial_number: '',
-        fuel_filter_qty: 0
-      })
+        fuel_filter_qty: 0,
+      }),
+      headers: { cookie: 'session=valid' },
     });
-
+    lastRequest = req;
     await POST(req);
-
     const params = sql.mock.calls[0][1];
     expect(params[5]).toBe('');
     expect(params[22]).toBe(0);

--- a/_/apps/web/src/app/api/utils/auth-middleware.js
+++ b/_/apps/web/src/app/api/utils/auth-middleware.js
@@ -9,12 +9,24 @@ const DEFAULT_ROLES = ["admin", "sales", "supervisor", "technician", "teknisi"];
 export async function requireRole(roles = DEFAULT_ROLES) {
   const session = await auth();
   if (!session?.user) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    return Response.json(
+      { error: "Unauthorized" },
+      {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   const normalizedRoles = roles.map((role) => ROLE_ALIAS[role] || role);
   if (!normalizedRoles.includes(session.user.role)) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return Response.json(
+      { error: "Forbidden" },
+      {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   return session;


### PR DESCRIPTION
## Summary
- enforce explicit JSON Content-Type on all units API responses
- add authentication tests for `/api/units`
- return JSON 404 for unmatched API routes

## Testing
- `npx vitest run --config src/app/api/vitest.config.ts` *(fails: document is not defined)*
- `npx vitest run src/app/api/units/route.test.js --config src/app/api/vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a781814c40832aa6c4f65f127eb60c