### PR TITLE
fix: remove base path from auth URLs

### DIFF
--- a/_/apps/web/.env
+++ b/_/apps/web/.env
@@ -4,5 +4,6 @@ DATABASE_URL="postgresql://neondb_owner:npg_WONhw6ZV5XgH@ep-soft-violet-a168edqt
 NEXT_PUBLIC_CREATE_BASE_URL=http://localhost:4000
 AUTH_SECRET=52831d5f2990efb56a0e15ba86f801719c6bf83b0ba4dbb8e240039560810eb1
 AUTH_URL=http://localhost:4000
+NEXTAUTH_URL=http://localhost:4000
 REDIS_URL=redis://default:mArbxdlVrQo0pSRbNjCtECNdHSYI2WPO@redis-12327.c1.ap-southeast-1-1.ec2.redns.redis-cloud.com:12327
 # REDIS_URL=redis://user:pass@localhost:6379

--- a/_/apps/web/.env.example
+++ b/_/apps/web/.env.example
@@ -4,4 +4,6 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/asset_management
 AUTH_SECRET=your-auth-secret
 NEXT_PUBLIC_CREATE_BASE_URL=http://localhost:4000
+AUTH_URL=http://localhost:4000
+NEXTAUTH_URL=http://localhost:4000
 REDIS_URL=redis://user:pass@localhost:6379


### PR DESCRIPTION
## Summary
- ensure AUTH_URL and NEXTAUTH_URL contain only the origin
- document correct auth origins in env example

## Testing
- `bun run dev`
- `bun run test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c2b953a8832a8ba9763a485cec88