### PR TITLE
Redirect unauthorized unit fetches to sign-in

### DIFF
--- a/_/apps/web/src/app/page.jsx
+++ b/_/apps/web/src/app/page.jsx
@@ -85,7 +85,7 @@ function HomePage() {
     return "Active";
   };
 
-  if (error) {
+  if (error && !error.message.toLowerCase().includes("unauthorized")) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">

--- a/_/apps/web/src/app/units/page.jsx
+++ b/_/apps/web/src/app/units/page.jsx
@@ -117,7 +117,7 @@ function UnitsPageContent() {
     return "Active";
   };
 
-  if (error) {
+  if (error && !error.message.toLowerCase().includes("unauthorized")) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">

--- a/_/apps/web/src/utils/useUnits.test.tsx
+++ b/_/apps/web/src/utils/useUnits.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -55,11 +56,31 @@ describe("useUnits", () => {
     });
   });
 
-  it("throws auth error when HTML is returned", async () => {
+  it("redirects and errors when HTML login page is returned", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       headers: { get: () => null },
       text: async () => "<html>Signin</html>",
+    } as any);
+
+    const { result } = renderHook(() => useUnits(""), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe(
+        "Unauthorized – redirecting to sign-in"
+      );
+    });
+  });
+
+  it("redirects and errors on 401 status", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      headers: { get: () => "application/json" },
+      json: async () => ({ error: "Unauthorized" }),
     } as any);
 
     const { result } = renderHook(() => useUnits(""), {

--- a/_/apps/web/src/utils/useUnits.ts
+++ b/_/apps/web/src/utils/useUnits.ts
@@ -59,6 +59,21 @@ const fetchUnits = async (searchTerm: string): Promise<UnitsResponse> => {
     headers: { Accept: "application/json" },
     credentials: "include",
   });
+  const redirectToSignIn = () => {
+    try {
+      window.location.replace(
+        "/account/signin?callbackUrl=" +
+          encodeURIComponent(window.location.pathname + window.location.search)
+      );
+    } catch {
+      // Ignore navigation errors in non-browser environments
+    }
+  };
+
+  if (response.status === 401) {
+    redirectToSignIn();
+    throw new Error("Unauthorized – redirecting to sign-in");
+  }
 
   const contentType = response.headers.get("content-type");
   let data: UnitsResponse;
@@ -74,6 +89,7 @@ const fetchUnits = async (searchTerm: string): Promise<UnitsResponse> => {
       lower.includes("login") ||
       lower.includes("unauth")
     ) {
+      redirectToSignIn();
       throw new Error("Unauthorized – redirecting to sign-in");
     }
 


### PR DESCRIPTION
## Summary
- Redirect users to sign-in when unit fetch responses return 401 or HTML login pages
- Suppress unauthorized errors in home and unit pages to rely on fetch redirect
- Add coverage for unauthorized fetch scenarios

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7d89e2c98832a9f37f0adda8c90a2