### PR TITLE
Reset seed script before inserting sample data

### DIFF
--- a/_/apps/web/prisma/seed.js
+++ b/_/apps/web/prisma/seed.js
@@ -3,6 +3,16 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
+  // Clear existing records to allow reseeding without unique constraint errors
+  await prisma.$transaction([
+    prisma.unitConsumable.deleteMany(),
+    prisma.serviceLog.deleteMany(),
+    prisma.unit.deleteMany(),
+    prisma.companyContact.deleteMany(),
+    prisma.consumableItem.deleteMany(),
+    prisma.company.deleteMany(),
+  ]);
+
   const acme = await prisma.company.create({
     data: {
       name: 'Acme Corp',


### PR DESCRIPTION
## Summary
- clear existing tables before seeding to avoid unique constraint violations

## Testing
- `bun run lint`
- `bun run test`
- `bun run prisma:seed` *(fails: Can't reach database server at ep-soft-violet-a168edqt-pooler.ap-southeast-1.aws.neon.tech:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a7df735300832a8ef2c3b0b8d1f25d