### PR TITLE
feat: allow signup auth action

### DIFF
--- a/_/apps/web/__create/is-auth-action.ts
+++ b/_/apps/web/__create/is-auth-action.ts
@@ -8,6 +8,7 @@ const authActions = [
     "error",
     "session",
     "webauthn-options",
+    "signup",
 ]
 
 export function isAuthAction(


### PR DESCRIPTION
## Summary
- allow signup to bypass auth restrictions by adding it to recognized auth actions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`
- `npm run dev` *(fails: react-router not found)*
- `curl -i http://localhost:3000/api/auth/signup` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e48439fc832aa92e6f90a497b09b