### PR TITLE
Improve signup API error handling

### DIFF
--- a/_/apps/web/src/app/account/signup/page.jsx
+++ b/_/apps/web/src/app/account/signup/page.jsx
@@ -89,11 +89,11 @@ export default function SignUpPage() {
         body: JSON.stringify(formData),
       });
 
-      const data = await response.json();
-
+      const text = await response.text();
       if (!response.ok) {
-        throw new Error(data.error || "Registration failed");
+        throw new Error(text || "Server returned an error");
       }
+      const data = text ? JSON.parse(text) : {};
 
       setSuccess(
         "Registration successful! Please check your phone for verification code.",
@@ -108,7 +108,11 @@ export default function SignUpPage() {
 
       setStep(2);
     } catch (err) {
-      setError(err.message || "Registration failed. Please try again.");
+      setError(
+        err.message
+          ? `Registration failed: ${err.message}`
+          : "Registration failed. Please try again."
+      );
     } finally {
       setLoading(false);
     }
@@ -131,18 +135,22 @@ export default function SignUpPage() {
         }),
       });
 
-      const data = await response.json();
-
+      const text = await response.text();
       if (!response.ok) {
-        throw new Error(data.error || "Verification failed");
+        throw new Error(text || "Server returned an error");
       }
+      const data = text ? JSON.parse(text) : {};
 
       setSuccess("Phone verified successfully! You can now sign in.");
       setTimeout(() => {
         window.location.href = "/account/signin";
       }, 2000);
     } catch (err) {
-      setError(err.message || "Verification failed. Please try again.");
+      setError(
+        err.message
+          ? `Verification failed: ${err.message}`
+          : "Verification failed. Please try again."
+      );
     } finally {
       setLoading(false);
     }
@@ -163,15 +171,19 @@ export default function SignUpPage() {
         }),
       });
 
-      const data = await response.json();
-
+      const text = await response.text();
       if (!response.ok) {
-        throw new Error(data.error || "Failed to resend code");
+        throw new Error(text || "Server returned an error");
       }
+      const data = text ? JSON.parse(text) : {};
 
       setSuccess("Verification code sent to your phone.");
     } catch (err) {
-      setError(err.message || "Failed to resend code. Please try again.");
+      setError(
+        err.message
+          ? `Failed to resend code: ${err.message}`
+          : "Failed to resend code. Please try again."
+      );
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Check `response.ok` before parsing JSON in signup flow
- Surface server error text for registration, verification, and code resend
- Clarify user-facing error messages

## Testing
- `bun run lint`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e4b361ac832aa1d6b4d330bec285