### PR TITLE
feat(web): add user model and seed

### DIFF
--- a/_/apps/web/prisma/migrations/0003_create_users_table/migration.sql
+++ b/_/apps/web/prisma/migrations/0003_create_users_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "public"."users" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phone" TEXT,
+    "role" TEXT NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "phone_verified" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "public"."users"("email");

--- a/_/apps/web/prisma/schema.prisma
+++ b/_/apps/web/prisma/schema.prisma
@@ -93,6 +93,21 @@ model UnitConsumable {
   @@map("unit_consumables")
 }
 
+model User {
+  id            Int      @id @default(autoincrement())
+  name          String
+  email         String   @unique
+  phone         String?
+  role          String
+  isActive      Boolean  @default(true)  @map("is_active")
+  phoneVerified Boolean  @default(false) @map("phone_verified")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt      @map("updated_at")
+  deletedAt     DateTime? @map("deleted_at")
+
+  @@map("users")
+}
+
 model AuthUser {
   id            String         @id @default(uuid()) @db.Uuid
   name          String?

--- a/_/apps/web/prisma/seed.js
+++ b/_/apps/web/prisma/seed.js
@@ -22,16 +22,22 @@ async function main() {
   ];
 
   for (const account of testAccounts) {
-    await prisma.$executeRaw`
-      INSERT INTO users (name, email, role, is_active, phone_verified)
-      VALUES (${account.name}, ${account.email}, ${account.role}, true, true)
-      ON CONFLICT (email) DO UPDATE SET
-        name = EXCLUDED.name,
-        role = EXCLUDED.role,
-        is_active = true,
-        phone_verified = true,
-        updated_at = CURRENT_TIMESTAMP;
-    `;
+    await prisma.user.upsert({
+      where: { email: account.email },
+      update: {
+        name: account.name,
+        role: account.role,
+        isActive: true,
+        phoneVerified: true,
+      },
+      create: {
+        name: account.name,
+        email: account.email,
+        role: account.role,
+        isActive: true,
+        phoneVerified: true,
+      },
+    });
   }
 
   const acme = await prisma.company.create({


### PR DESCRIPTION
## Summary
- add User model to Prisma schema
- seed test accounts via Prisma client
- create users table migration

## Testing
- `npx prisma migrate dev --name create_users_table` *(fails: Can't reach database server)*
- `bun prisma:seed` *(fails: Cannot find module './Arbitrary.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a7e4754714832abf66ee9fbca70d1f