### PR TITLE
fix: exclude signup route from auth action detection

### DIFF
--- a/_/apps/web/__create/is-auth-action.ts
+++ b/_/apps/web/__create/is-auth-action.ts
@@ -8,7 +8,6 @@ const authActions = [
     "error",
     "session",
     "webauthn-options",
-    "signup",
 ]
 
 export function isAuthAction(


### PR DESCRIPTION
## Summary
- remove `signup` from the list of `authActions` so `/api/auth/signup` is treated as a custom route

## Testing
- `bun run lint`
- `bun test` *(fails: ClientFetchError: Unexpected response content-type, ReferenceError: document is not defined, cannot find module '@auth/create')*


------
https://chatgpt.com/codex/tasks/task_e_68a7e93dd250832aa6f4642028de7c92