### PR TITLE
feat(web): add verification token primary key

### DIFF
--- a/_/apps/web/prisma/migrations/20250822040210_add-verification-token-pk/migration.sql
+++ b/_/apps/web/prisma/migrations/20250822040210_add-verification-token-pk/migration.sql
@@ -1,0 +1,6 @@
+-- DropIndex
+DROP INDEX "public"."auth_verification_token_identifier_token_key";
+
+-- AlterTable
+ALTER TABLE "public"."auth_verification_token" ADD COLUMN "id" SERIAL NOT NULL,
+ADD CONSTRAINT "auth_verification_token_pkey" PRIMARY KEY ("id");

--- a/_/apps/web/prisma/schema.prisma
+++ b/_/apps/web/prisma/schema.prisma
@@ -151,10 +151,10 @@ model AuthSession {
 }
 
 model AuthVerificationToken {
+  id         Int      @id @default(autoincrement())
   identifier String
   token      String   @unique
   expires    DateTime
 
-  @@unique([identifier, token])
   @@map("auth_verification_token")
 }


### PR DESCRIPTION
## Summary
- add auto-incrementing primary key to AuthVerificationToken model
- include SQL migration for new verification token primary key

## Testing
- `bunx prisma migrate dev --name add-verification-token-pk` *(fails: Can't reach database server)*
- `bunx prisma generate` *(hangs after loading schema; terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eae80c04832aa4e4ce28a5e28a7b