### PR TITLE
Add ServiceLog updatedAt and migrate service log writes to Prisma

### DIFF
--- a/_/apps/web/prisma/migrations/0004_add-servicelog-updated-at/migration.sql
+++ b/_/apps/web/prisma/migrations/0004_add-servicelog-updated-at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."ServiceLog" ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL;

--- a/_/apps/web/prisma/schema.prisma
+++ b/_/apps/web/prisma/schema.prisma
@@ -21,51 +21,52 @@ model Company {
   contacts      CompanyContact[]
   units         Unit[]
   createdAt     DateTime         @default(now()) @map("created_at")
-  updatedAt     DateTime         @updatedAt       @map("updated_at")
+  updatedAt     DateTime         @updatedAt @map("updated_at")
   deletedAt     DateTime?        @map("deleted_at")
 }
 
 model CompanyContact {
-  id         Int      @id @default(autoincrement())
-  company    Company  @relation(fields: [companyId], references: [id])
-  companyId  Int      @map("company_id")
-  name       String
-  position   String?
-  email      String?
-  phone      String?
-  isPrimary  Boolean? @default(false) @map("is_primary")
-  notes      String?
-  createdAt  DateTime @default(now()) @map("created_at")
-  updatedAt  DateTime @updatedAt       @map("updated_at")
-  deletedAt  DateTime? @map("deleted_at")
+  id        Int       @id @default(autoincrement())
+  company   Company   @relation(fields: [companyId], references: [id])
+  companyId Int       @map("company_id")
+  name      String
+  position  String?
+  email     String?
+  phone     String?
+  isPrimary Boolean?  @default(false) @map("is_primary")
+  notes     String?
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
 }
 
 model Unit {
-  id                    Int            @id @default(autoincrement())
-  company               Company?       @relation(fields: [companyId], references: [id])
-  companyId             Int?           @map("company_id")
-  unitName              String         @map("unit_name")
-  model                 String?
-  serialNumber          String?        @map("serial_number")
-  installDate           DateTime?      @map("install_date")
-  accessToken           String         @unique @map("access_token")
-  specifications        String?
-  warrantyEnd           DateTime?      @map("warranty_end")
-  isActive              Boolean        @default(true) @map("is_active")
-  createdAt             DateTime       @default(now()) @map("created_at")
-  updatedAt             DateTime       @updatedAt       @map("updated_at")
-  deletedAt             DateTime?      @map("deleted_at")
-  serviceLogs           ServiceLog[]
-  unitConsumables       UnitConsumable[]
+  id              Int              @id @default(autoincrement())
+  company         Company?         @relation(fields: [companyId], references: [id])
+  companyId       Int?             @map("company_id")
+  unitName        String           @map("unit_name")
+  model           String?
+  serialNumber    String?          @map("serial_number")
+  installDate     DateTime?        @map("install_date")
+  accessToken     String           @unique @map("access_token")
+  specifications  String?
+  warrantyEnd     DateTime?        @map("warranty_end")
+  isActive        Boolean          @default(true) @map("is_active")
+  createdAt       DateTime         @default(now()) @map("created_at")
+  updatedAt       DateTime         @updatedAt @map("updated_at")
+  deletedAt       DateTime?        @map("deleted_at")
+  serviceLogs     ServiceLog[]
+  unitConsumables UnitConsumable[]
 }
 
 model ServiceLog {
-  id        Int      @id @default(autoincrement())
-  unit      Unit     @relation(fields: [unitId], references: [id])
-  unitId    Int      @map("unit_id")
-  hourMeter Int      @map("hour_meter")
-  notes     String?
-  createdAt DateTime @default(now()) @map("created_at")
+  id              Int              @id @default(autoincrement())
+  unit            Unit             @relation(fields: [unitId], references: [id])
+  unitId          Int              @map("unit_id")
+  hourMeter       Int              @map("hour_meter")
+  notes           String?
+  createdAt       DateTime         @default(now()) @map("created_at")
+  updatedAt       DateTime         @updatedAt @map("updated_at")
   unitConsumables UnitConsumable[]
 }
 
@@ -80,38 +81,38 @@ model ConsumableItem {
 }
 
 model UnitConsumable {
-  id             Int             @id @default(autoincrement())
-  unit           Unit            @relation(fields: [unitId], references: [id], onDelete: Cascade)
-  unitId         Int             @map("unit_id")
-  consumable     ConsumableItem  @relation(fields: [consumableId], references: [id])
-  consumableId   Int             @map("consumable_id")
-  serviceLog     ServiceLog?     @relation(fields: [serviceLogId], references: [id], onDelete: Cascade)
-  serviceLogId   Int?            @map("service_log_id")
-  quantity       Int
-  createdAt      DateTime        @default(now()) @map("created_at")
+  id           Int            @id @default(autoincrement())
+  unit         Unit           @relation(fields: [unitId], references: [id], onDelete: Cascade)
+  unitId       Int            @map("unit_id")
+  consumable   ConsumableItem @relation(fields: [consumableId], references: [id])
+  consumableId Int            @map("consumable_id")
+  serviceLog   ServiceLog?    @relation(fields: [serviceLogId], references: [id], onDelete: Cascade)
+  serviceLogId Int?           @map("service_log_id")
+  quantity     Int
+  createdAt    DateTime       @default(now()) @map("created_at")
 
   @@map("unit_consumables")
 }
 
 model User {
-  id            Int      @id @default(autoincrement())
+  id            Int       @id @default(autoincrement())
   name          String
-  email         String   @unique
+  email         String    @unique
   phone         String?
   role          String
-  isActive      Boolean  @default(true)  @map("is_active")
-  phoneVerified Boolean  @default(false) @map("phone_verified")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt      @map("updated_at")
+  isActive      Boolean   @default(true) @map("is_active")
+  phoneVerified Boolean   @default(false) @map("phone_verified")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
   deletedAt     DateTime? @map("deleted_at")
 
   @@map("users")
 }
 
 model AuthUser {
-  id            String         @id @default(uuid()) @db.Uuid
+  id            String        @id @default(uuid()) @db.Uuid
   name          String?
-  email         String?        @unique
+  email         String?       @unique
   emailVerified DateTime?
   image         String?
   accounts      AuthAccount[]
@@ -121,29 +122,29 @@ model AuthUser {
 }
 
 model AuthAccount {
-  id                String    @id @default(uuid()) @db.Uuid
-  userId            String    @db.Uuid
+  id                String   @id @default(uuid()) @db.Uuid
+  userId            String   @db.Uuid
   type              String
   provider          String
   providerAccountId String
-  refreshToken      String?   @map("refresh_token")
-  accessToken       String?   @map("access_token")
-  expiresAt         Int?      @map("expires_at")
-  tokenType         String?   @map("token_type")
+  refreshToken      String?  @map("refresh_token")
+  accessToken       String?  @map("access_token")
+  expiresAt         Int?     @map("expires_at")
+  tokenType         String?  @map("token_type")
   scope             String?
-  idToken           String?   @map("id_token")
-  sessionState      String?   @map("session_state")
+  idToken           String?  @map("id_token")
+  sessionState      String?  @map("session_state")
   password          String?
-  user              AuthUser  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user              AuthUser @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
   @@map("auth_accounts")
 }
 
 model AuthSession {
-  id           String    @id @default(uuid()) @db.Uuid
-  sessionToken String    @unique
-  userId       String    @db.Uuid
+  id           String   @id @default(uuid()) @db.Uuid
+  sessionToken String   @unique
+  userId       String   @db.Uuid
   expires      DateTime
   user         AuthUser @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/_/apps/web/src/app/api/service-logs/[id]/route.js
+++ b/_/apps/web/src/app/api/service-logs/[id]/route.js
@@ -1,4 +1,5 @@
 import sql from "@/app/api/utils/sql";
+import prisma from "@/app/api/utils/prisma";
 import { requireRole } from "@/app/api/utils/auth-middleware";
 import { z } from "zod";
 
@@ -96,60 +97,64 @@ export async function PUT(request, { params }) {
     }
     const { hour_meter, notes, materials, consumables, photos } = parsed.data;
 
-    await sql.transaction(async (tx) => {
-      await tx`
-        UPDATE service_logs
-        SET hour_meter = COALESCE(${hour_meter}, hour_meter),
-            notes = COALESCE(${notes}, notes)
-        WHERE id = ${id}
-      `;
+    await prisma.$transaction(async (tx) => {
+      await tx.serviceLog.update({
+        where: { id: Number(id) },
+        data: {
+          hourMeter: hour_meter ?? undefined,
+          notes: notes ?? undefined,
+        },
+      });
 
-      const existingMaterials = await tx`
+      const existingMaterials = await tx.$queryRaw`
         SELECT material_id, quantity FROM service_log_materials
         WHERE service_log_id = ${id}
       `;
       for (const m of existingMaterials) {
-        await tx`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
+        await tx.$executeRaw`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
       }
-      await tx`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
+      await tx.$executeRaw`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
 
       for (const m of materials) {
-        await tx`
-          INSERT INTO service_log_materials (service_log_id, material_id, quantity)
-          VALUES (${id}, ${m.material_id}, ${m.quantity})
-        `;
-        await tx`
-          UPDATE materials SET stock = stock - ${m.quantity} WHERE id = ${m.material_id}
-        `;
+        await tx.$executeRaw`INSERT INTO service_log_materials (service_log_id, material_id, quantity) VALUES (${id}, ${m.material_id}, ${m.quantity})`;
+        await tx.$executeRaw`UPDATE materials SET stock = stock - ${m.quantity} WHERE id = ${m.material_id}`;
       }
 
-      const existingConsumables = await tx`
-        SELECT consumable_id, quantity FROM unit_consumables
-        WHERE service_log_id = ${id}
-      `;
+      const existingConsumables = await tx.unitConsumable.findMany({
+        where: { serviceLogId: Number(id) },
+        select: { consumableId: true, quantity: true },
+      });
       for (const c of existingConsumables) {
-        await tx`UPDATE consumable_items SET stock = stock + ${c.quantity} WHERE id = ${c.consumable_id}`;
+        await tx.consumableItem.update({
+          where: { id: c.consumableId },
+          data: { stock: { increment: c.quantity } },
+        });
       }
-      await tx`DELETE FROM unit_consumables WHERE service_log_id = ${id}`;
+      await tx.unitConsumable.deleteMany({ where: { serviceLogId: Number(id) } });
 
-      const unitRow = await tx`SELECT unit_id FROM service_logs WHERE id = ${id}`;
-      const unitId = unitRow[0].unit_id;
+      const unit = await tx.serviceLog.findUnique({
+        where: { id: Number(id) },
+        select: { unitId: true },
+      });
+      const unitId = unit.unitId;
       for (const c of consumables) {
-        await tx`
-          INSERT INTO unit_consumables (service_log_id, unit_id, consumable_id, quantity)
-          VALUES (${id}, ${unitId}, ${c.consumable_id}, ${c.quantity})
-        `;
-        await tx`
-          UPDATE consumable_items SET stock = stock - ${c.quantity} WHERE id = ${c.consumable_id}
-        `;
+        await tx.unitConsumable.create({
+          data: {
+            serviceLogId: Number(id),
+            unitId,
+            consumableId: c.consumable_id,
+            quantity: c.quantity,
+          },
+        });
+        await tx.consumableItem.update({
+          where: { id: c.consumable_id },
+          data: { stock: { decrement: c.quantity } },
+        });
       }
 
-      await tx`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
+      await tx.$executeRaw`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
       for (const url of photos) {
-        await tx`
-          INSERT INTO service_log_photos (service_log_id, url)
-          VALUES (${id}, ${url})
-        `;
+        await tx.$executeRaw`INSERT INTO service_log_photos (service_log_id, url) VALUES (${id}, ${url})`;
       }
     });
 
@@ -171,27 +176,30 @@ export async function DELETE(request, { params }) {
 
     const { id } = params;
 
-    await sql.transaction(async (tx) => {
-      const materials = await tx`
+    await prisma.$transaction(async (tx) => {
+      const materials = await tx.$queryRaw`
         SELECT material_id, quantity FROM service_log_materials
         WHERE service_log_id = ${id}
       `;
       for (const m of materials) {
-        await tx`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
+        await tx.$executeRaw`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
       }
-      await tx`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
+      await tx.$executeRaw`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
 
-      const consumables = await tx`
-        SELECT consumable_id, quantity FROM unit_consumables
-        WHERE service_log_id = ${id}
-      `;
+      const consumables = await tx.unitConsumable.findMany({
+        where: { serviceLogId: Number(id) },
+        select: { consumableId: true, quantity: true },
+      });
       for (const c of consumables) {
-        await tx`UPDATE consumable_items SET stock = stock + ${c.quantity} WHERE id = ${c.consumable_id}`;
+        await tx.consumableItem.update({
+          where: { id: c.consumableId },
+          data: { stock: { increment: c.quantity } },
+        });
       }
-      await tx`DELETE FROM unit_consumables WHERE service_log_id = ${id}`;
+      await tx.unitConsumable.deleteMany({ where: { serviceLogId: Number(id) } });
 
-      await tx`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
-      await tx`DELETE FROM service_logs WHERE id = ${id}`;
+      await tx.$executeRaw`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
+      await tx.serviceLog.delete({ where: { id: Number(id) } });
     });
 
     return Response.json({ message: "Service log deleted" });

--- a/_/apps/web/src/app/api/service-logs/route.js
+++ b/_/apps/web/src/app/api/service-logs/route.js
@@ -1,4 +1,4 @@
-import sql from "@/app/api/utils/sql";
+import prisma from "@/app/api/utils/prisma";
 import { requireRole } from "@/app/api/utils/auth-middleware";
 import { z } from "zod";
 
@@ -8,14 +8,22 @@ export async function GET() {
     const session = await requireRole();
     if (session instanceof Response) return session;
 
-    const logs = await sql`
-      SELECT sl.*, u.unit_name
-      FROM service_logs sl
-      LEFT JOIN units u ON sl.unit_id = u.id
-      ORDER BY sl.created_at DESC
-    `;
+    const logs = await prisma.serviceLog.findMany({
+      include: { unit: { select: { unitName: true } } },
+      orderBy: { createdAt: "desc" },
+    });
 
-    return Response.json({ service_logs: logs });
+    return Response.json({
+      service_logs: logs.map((log) => ({
+        id: log.id,
+        unit_id: log.unitId,
+        hour_meter: log.hourMeter,
+        notes: log.notes,
+        created_at: log.createdAt,
+        updated_at: log.updatedAt,
+        unit_name: log.unit?.unitName,
+      })),
+    });
   } catch (error) {
     console.error("Error fetching service logs:", error);
     return Response.json(
@@ -65,46 +73,49 @@ export async function POST(request) {
     }
     const { unit_id, hour_meter, notes, materials, consumables, photos } = parsed.data;
 
-    const log = await sql.transaction(async (tx) => {
-      const [inserted] = await tx`
-        INSERT INTO service_logs (unit_id, hour_meter, notes)
-        VALUES (${unit_id}, ${hour_meter}, ${notes || null})
-        RETURNING id, unit_id, hour_meter, notes, created_at
-      `;
+    const log = await prisma.$transaction(async (tx) => {
+      const inserted = await tx.serviceLog.create({
+        data: { unitId: unit_id, hourMeter: hour_meter, notes },
+        select: { id: true, unitId: true, hourMeter: true, notes: true, createdAt: true, updatedAt: true },
+      });
 
       for (const m of materials) {
-        await tx`
-          INSERT INTO service_log_materials (service_log_id, material_id, quantity)
-          VALUES (${inserted.id}, ${m.material_id}, ${m.quantity})
-        `;
-        await tx`
-          UPDATE materials SET stock = stock - ${m.quantity}
-          WHERE id = ${m.material_id}
-        `;
+        await tx.$executeRaw`INSERT INTO service_log_materials (service_log_id, material_id, quantity) VALUES (${inserted.id}, ${m.material_id}, ${m.quantity})`;
+        await tx.$executeRaw`UPDATE materials SET stock = stock - ${m.quantity} WHERE id = ${m.material_id}`;
       }
 
       for (const c of consumables) {
-        await tx`
-          INSERT INTO unit_consumables (service_log_id, unit_id, consumable_id, quantity)
-          VALUES (${inserted.id}, ${unit_id}, ${c.consumable_id}, ${c.quantity})
-        `;
-        await tx`
-          UPDATE consumable_items SET stock = stock - ${c.quantity}
-          WHERE id = ${c.consumable_id}
-        `;
+        await tx.unitConsumable.create({
+          data: {
+            serviceLogId: inserted.id,
+            unitId: unit_id,
+            consumableId: c.consumable_id,
+            quantity: c.quantity,
+          },
+        });
+        await tx.consumableItem.update({
+          where: { id: c.consumable_id },
+          data: { stock: { decrement: c.quantity } },
+        });
       }
 
       for (const url of photos) {
-        await tx`
-          INSERT INTO service_log_photos (service_log_id, url)
-          VALUES (${inserted.id}, ${url})
-        `;
+        await tx.$executeRaw`INSERT INTO service_log_photos (service_log_id, url) VALUES (${inserted.id}, ${url})`;
       }
 
       return inserted;
     });
 
-    return Response.json({ service_log: log }, { status: 201 });
+    return Response.json({
+      service_log: {
+        id: log.id,
+        unit_id: log.unitId,
+        hour_meter: log.hourMeter,
+        notes: log.notes,
+        created_at: log.createdAt,
+        updated_at: log.updatedAt,
+      },
+    }, { status: 201 });
   } catch (error) {
     console.error("Error creating service log:", error);
     return Response.json(


### PR DESCRIPTION
## Summary
- add `updatedAt` field to Prisma `ServiceLog` model and generate migration
- rewrite service log API endpoints to use Prisma so `updatedAt` is maintained

## Testing
- `bunx prisma migrate dev --name add-servicelog-updated-at` *(fails: Can't reach database server)*
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eb0e4d5c832abe1ba83d2f82291b