### PR TITLE
feat: enforce unique UnitConsumable entries

### DIFF
--- a/_/apps/web/prisma/migrations/20250901000000_unique-unit-consumable/migration.sql
+++ b/_/apps/web/prisma/migrations/20250901000000_unique-unit-consumable/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "unit_consumables_unit_id_consumable_id_service_log_id_key" ON "unit_consumables"("unit_id", "consumable_id", "service_log_id");

--- a/_/apps/web/prisma/schema.prisma
+++ b/_/apps/web/prisma/schema.prisma
@@ -91,6 +91,7 @@ model UnitConsumable {
   quantity     Int
   createdAt    DateTime       @default(now()) @map("created_at")
 
+  @@unique([unitId, consumableId, serviceLogId])
   @@map("unit_consumables")
 }
 

--- a/_/apps/web/src/app/api/service-logs/[id]/route.js
+++ b/_/apps/web/src/app/api/service-logs/[id]/route.js
@@ -137,18 +137,30 @@ export async function PUT(request, { params }) {
         select: { unitId: true },
       });
       const unitId = unit.unitId;
-      for (const c of consumables) {
+
+      const consumableTotals = consumables.reduce(
+        (acc, { consumable_id, quantity }) => {
+          acc.set(
+            consumable_id,
+            (acc.get(consumable_id) ?? 0) + quantity,
+          );
+          return acc;
+        },
+        new Map(),
+      );
+
+      for (const [consumableId, totalQty] of consumableTotals) {
         await tx.unitConsumable.create({
           data: {
             serviceLogId: Number(id),
             unitId,
-            consumableId: c.consumable_id,
-            quantity: c.quantity,
+            consumableId,
+            quantity: totalQty,
           },
         });
         await tx.consumableItem.update({
-          where: { id: c.consumable_id },
-          data: { stock: { decrement: c.quantity } },
+          where: { id: consumableId },
+          data: { stock: { decrement: totalQty } },
         });
       }
 

--- a/_/apps/web/src/app/api/service-logs/route.js
+++ b/_/apps/web/src/app/api/service-logs/route.js
@@ -84,18 +84,28 @@ export async function POST(request) {
         await tx.$executeRaw`UPDATE materials SET stock = stock - ${m.quantity} WHERE id = ${m.material_id}`;
       }
 
-      for (const c of consumables) {
+      const consumableTotals = consumables.reduce(
+        (acc, { consumable_id, quantity }) => {
+          acc.set(
+            consumable_id,
+            (acc.get(consumable_id) ?? 0) + quantity,
+          );
+          return acc;
+        },
+        new Map(),
+      );
+      for (const [consumableId, totalQty] of consumableTotals) {
         await tx.unitConsumable.create({
           data: {
             serviceLogId: inserted.id,
             unitId: unit_id,
-            consumableId: c.consumable_id,
-            quantity: c.quantity,
+            consumableId,
+            quantity: totalQty,
           },
         });
         await tx.consumableItem.update({
-          where: { id: c.consumable_id },
-          data: { stock: { decrement: c.quantity } },
+          where: { id: consumableId },
+          data: { stock: { decrement: totalQty } },
         });
       }
 


### PR DESCRIPTION
## Summary
- enforce unique combination of unit, consumable and service log in schema
- aggregate duplicate consumables when creating or updating service logs
- add migration for new composite unique index

## Testing
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" bunx prisma migrate dev --name unique-unit-consumable` *(fails: Can't reach database server at `localhost:5432`)*
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ed45a494832aa8a31604c48bbe6d