### PR TITLE
feat(web): add db setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,12 @@ Create a `.env` file in each app directory with the following keys. Use the prov
 
 This project uses [Prisma](https://www.prisma.io/) for managing PostgreSQL migrations and seeding.
 
-### Migrations
+### Database Initialization
+
+Run the following command to deploy migrations and seed the database during environment setup:
 
 ```
-bun run prisma:migrate
-```
-
-### Seeding
-
-```
-bun run prisma:seed
+bun run db:setup
 ```
 
 The seed script populates sample companies, contacts, units and service logs.

--- a/_/apps/web/package.json
+++ b/_/apps/web/package.json
@@ -7,13 +7,14 @@
 		"build": "vite build",
 		"typecheck": "react-router typegen && tsc --noEmit",
 		"reminder-worker": "node src/jobs/reminderWorker.js",
-		"prisma:migrate": "prisma migrate dev",
-		"prisma:seed": "prisma db seed",
-		"lint": "eslint .",
-		"test": "vitest run && vitest run --config src/app/api/vitest.config.ts",
-		"test:e2e": "playwright test",
-		"postinstall": "patch-package",
-		"preprisma:seed": "prisma generate"
+                "prisma:migrate": "prisma migrate dev",
+                "prisma:seed": "prisma db seed",
+                "db:setup": "prisma migrate deploy && prisma db seed",
+                "lint": "eslint .",
+                "test": "vitest run && vitest run --config src/app/api/vitest.config.ts",
+                "test:e2e": "playwright test",
+                "postinstall": "patch-package",
+                "preprisma:seed": "prisma generate"
 	},
 	"dependencies": {
 		"@auth/core": "^0.37.2",


### PR DESCRIPTION
## Summary
- add db:setup script to run migrations and seed database
- document how to initialize database with bun run db:setup

## Testing
- `bun run lint`
- `bun run test`
- `bun run db:setup` *(fails: Can't reach database server at `ep-soft-violet-a168edqt-pooler.ap-southeast-1.aws.neon.tech:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eecacd40832a97d5f4ab0fa317a6