### PR TITLE
refactor: model service log materials and photos

### DIFF
--- a/_/apps/web/prisma/schema.prisma
+++ b/_/apps/web/prisma/schema.prisma
@@ -74,8 +74,40 @@ model ServiceLog {
   createdAt       DateTime         @default(now()) @map("created_at")
   updatedAt       DateTime         @updatedAt @map("updated_at")
   unitConsumables UnitConsumable[]
+  materials       ServiceLogMaterial[]
+  photos          ServiceLogPhoto[]
 
   @@map("service_logs")
+}
+
+model Material {
+  id                  Int                  @id @default(autoincrement())
+  name                String
+  stock               Int                  @default(0)
+  createdAt           DateTime             @default(now()) @map("created_at")
+  serviceLogMaterials ServiceLogMaterial[]
+
+  @@map("materials")
+}
+
+model ServiceLogMaterial {
+  serviceLog   ServiceLog @relation(fields: [serviceLogId], references: [id], onDelete: Cascade)
+  serviceLogId Int        @map("service_log_id")
+  material     Material   @relation(fields: [materialId], references: [id])
+  materialId   Int        @map("material_id")
+  quantity     Int
+
+  @@id([serviceLogId, materialId])
+  @@map("service_log_materials")
+}
+
+model ServiceLogPhoto {
+  id           Int        @id @default(autoincrement())
+  serviceLog   ServiceLog @relation(fields: [serviceLogId], references: [id], onDelete: Cascade)
+  serviceLogId Int        @map("service_log_id")
+  url          String
+
+  @@map("service_log_photos")
 }
 
 model ConsumableItem {

--- a/_/apps/web/prisma/seed.js
+++ b/_/apps/web/prisma/seed.js
@@ -6,8 +6,11 @@ async function main() {
   // Clear existing records to allow reseeding without unique constraint errors
   await prisma.$transaction([
     prisma.user.deleteMany(),
+    prisma.serviceLogPhoto.deleteMany(),
+    prisma.serviceLogMaterial.deleteMany(),
     prisma.unitConsumable.deleteMany(),
     prisma.serviceLog.deleteMany(),
+    prisma.material.deleteMany(),
     prisma.unit.deleteMany(),
     prisma.companyContact.deleteMany(),
     prisma.consumableItem.deleteMany(),

--- a/_/apps/web/src/app/api/service-logs/[id]/route.js
+++ b/_/apps/web/src/app/api/service-logs/[id]/route.js
@@ -1,4 +1,3 @@
-import sql from "@/app/api/utils/sql";
 import prisma from "@/app/api/utils/prisma";
 import { requireRole } from "@/app/api/utils/auth-middleware";
 import { z } from "zod";
@@ -10,42 +9,40 @@ export async function GET(request, { params }) {
     if (session instanceof Response) return session;
 
     const { id } = params;
+    const log = await prisma.serviceLog.findUnique({
+      where: { id: Number(id) },
+      include: {
+        unit: { select: { unitName: true } },
+        materials: { include: { material: { select: { name: true } } } },
+        unitConsumables: { include: { consumable: { select: { name: true } } } },
+        photos: { select: { url: true } },
+      },
+    });
 
-    const logs = await sql`
-      SELECT sl.*, u.unit_name
-      FROM service_logs sl
-      LEFT JOIN units u ON sl.unit_id = u.id
-      WHERE sl.id = ${id}
-    `;
-
-    if (logs.length === 0) {
+    if (!log) {
       return Response.json({ error: "Service log not found" }, { status: 404 });
     }
 
-    const materials = await sql`
-      SELECT slm.material_id, slm.quantity, m.name as material_name
-      FROM service_log_materials slm
-      LEFT JOIN materials m ON slm.material_id = m.id
-      WHERE slm.service_log_id = ${id}
-    `;
-
-    const consumables = await sql`
-      SELECT uc.consumable_id, uc.quantity, ci.name as consumable_name
-      FROM unit_consumables uc
-      LEFT JOIN consumable_items ci ON uc.consumable_id = ci.id
-      WHERE uc.service_log_id = ${id}
-    `;
-
-    const photos = await sql`
-      SELECT url FROM service_log_photos WHERE service_log_id = ${id}
-    `;
-
     return Response.json({
       service_log: {
-        ...logs[0],
-        materials,
-        consumables,
-        photos,
+        id: log.id,
+        unit_id: log.unitId,
+        hour_meter: log.hourMeter,
+        notes: log.notes,
+        created_at: log.createdAt,
+        updated_at: log.updatedAt,
+        unit_name: log.unit?.unitName,
+        materials: log.materials.map((m) => ({
+          material_id: m.materialId,
+          material_name: m.material?.name,
+          quantity: m.quantity,
+        })),
+        consumables: log.unitConsumables.map((c) => ({
+          consumable_id: c.consumableId,
+          consumable_name: c.consumable?.name,
+          quantity: c.quantity,
+        })),
+        photos: log.photos.map((p) => ({ url: p.url })),
       },
     });
   } catch (error) {
@@ -106,18 +103,32 @@ export async function PUT(request, { params }) {
         },
       });
 
-      const existingMaterials = await tx.$queryRaw`
-        SELECT material_id, quantity FROM service_log_materials
-        WHERE service_log_id = ${id}
-      `;
+      const existingMaterials = await tx.serviceLogMaterial.findMany({
+        where: { serviceLogId: Number(id) },
+        select: { materialId: true, quantity: true },
+      });
       for (const m of existingMaterials) {
-        await tx.$executeRaw`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
+        await tx.material.update({
+          where: { id: m.materialId },
+          data: { stock: { increment: m.quantity } },
+        });
       }
-      await tx.$executeRaw`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
+      await tx.serviceLogMaterial.deleteMany({
+        where: { serviceLogId: Number(id) },
+      });
 
       for (const m of materials) {
-        await tx.$executeRaw`INSERT INTO service_log_materials (service_log_id, material_id, quantity) VALUES (${id}, ${m.material_id}, ${m.quantity})`;
-        await tx.$executeRaw`UPDATE materials SET stock = stock - ${m.quantity} WHERE id = ${m.material_id}`;
+        await tx.serviceLogMaterial.create({
+          data: {
+            serviceLogId: Number(id),
+            materialId: m.material_id,
+            quantity: m.quantity,
+          },
+        });
+        await tx.material.update({
+          where: { id: m.material_id },
+          data: { stock: { decrement: m.quantity } },
+        });
       }
 
       const existingConsumables = await tx.unitConsumable.findMany({
@@ -164,9 +175,11 @@ export async function PUT(request, { params }) {
         });
       }
 
-      await tx.$executeRaw`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
+      await tx.serviceLogPhoto.deleteMany({ where: { serviceLogId: Number(id) } });
       for (const url of photos) {
-        await tx.$executeRaw`INSERT INTO service_log_photos (service_log_id, url) VALUES (${id}, ${url})`;
+        await tx.serviceLogPhoto.create({
+          data: { serviceLogId: Number(id), url },
+        });
       }
     });
 
@@ -189,14 +202,19 @@ export async function DELETE(request, { params }) {
     const { id } = params;
 
     await prisma.$transaction(async (tx) => {
-      const materials = await tx.$queryRaw`
-        SELECT material_id, quantity FROM service_log_materials
-        WHERE service_log_id = ${id}
-      `;
+      const materials = await tx.serviceLogMaterial.findMany({
+        where: { serviceLogId: Number(id) },
+        select: { materialId: true, quantity: true },
+      });
       for (const m of materials) {
-        await tx.$executeRaw`UPDATE materials SET stock = stock + ${m.quantity} WHERE id = ${m.material_id}`;
+        await tx.material.update({
+          where: { id: m.materialId },
+          data: { stock: { increment: m.quantity } },
+        });
       }
-      await tx.$executeRaw`DELETE FROM service_log_materials WHERE service_log_id = ${id}`;
+      await tx.serviceLogMaterial.deleteMany({
+        where: { serviceLogId: Number(id) },
+      });
 
       const consumables = await tx.unitConsumable.findMany({
         where: { serviceLogId: Number(id) },
@@ -210,7 +228,7 @@ export async function DELETE(request, { params }) {
       }
       await tx.unitConsumable.deleteMany({ where: { serviceLogId: Number(id) } });
 
-      await tx.$executeRaw`DELETE FROM service_log_photos WHERE service_log_id = ${id}`;
+      await tx.serviceLogPhoto.deleteMany({ where: { serviceLogId: Number(id) } });
       await tx.serviceLog.delete({ where: { id: Number(id) } });
     });
 

--- a/_/apps/web/src/app/api/service-logs/route.js
+++ b/_/apps/web/src/app/api/service-logs/route.js
@@ -80,8 +80,17 @@ export async function POST(request) {
       });
 
       for (const m of materials) {
-        await tx.$executeRaw`INSERT INTO service_log_materials (service_log_id, material_id, quantity) VALUES (${inserted.id}, ${m.material_id}, ${m.quantity})`;
-        await tx.$executeRaw`UPDATE materials SET stock = stock - ${m.quantity} WHERE id = ${m.material_id}`;
+        await tx.serviceLogMaterial.create({
+          data: {
+            serviceLogId: inserted.id,
+            materialId: m.material_id,
+            quantity: m.quantity,
+          },
+        });
+        await tx.material.update({
+          where: { id: m.material_id },
+          data: { stock: { decrement: m.quantity } },
+        });
       }
 
       const consumableTotals = consumables.reduce(
@@ -110,7 +119,9 @@ export async function POST(request) {
       }
 
       for (const url of photos) {
-        await tx.$executeRaw`INSERT INTO service_log_photos (service_log_id, url) VALUES (${inserted.id}, ${url})`;
+        await tx.serviceLogPhoto.create({
+          data: { serviceLogId: inserted.id, url },
+        });
       }
 
       return inserted;


### PR DESCRIPTION
## Summary
- add Prisma models for materials, service log materials, and photos
- replace raw SQL with Prisma in service log APIs
- clear new tables in seed script

## Testing
- `bunx prisma format` *(fails: Cannot find module '/workspace/asset_management_ver3/_/apps/web/node_modules/prisma/build/types.js')*
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a80150d1ac832a98dcb93fade1bed5