### PR TITLE
Fix Prisma config to load environment variables

### DIFF
--- a/_/apps/web/prisma.config.ts
+++ b/_/apps/web/prisma.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig } from 'prisma'
+import 'dotenv/config'
+import { defineConfig } from 'prisma/config'
 
 export default defineConfig({
   seed: 'node prisma/seed.js',


### PR DESCRIPTION
## Summary
- fix Prisma config import to avoid missing build/types.js
- load dotenv in Prisma config so DATABASE_URL is available

## Testing
- `bunx prisma generate`
- `bun run db:setup` *(fails: Can't reach database server at `ep-soft-violet-a168edqt-pooler.ap-southeast-1.aws.neon.tech:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8075d945c832ab13b5ecc08d3655e