### PR TITLE
Add migration for service log materials and photos tables

### DIFF
--- a/_/apps/web/prisma/migrations/20250822072618_add_service_log_tables/migration.sql
+++ b/_/apps/web/prisma/migrations/20250822072618_add_service_log_tables/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "public"."materials" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "stock" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "materials_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."service_log_materials" (
+    "service_log_id" INTEGER NOT NULL,
+    "material_id" INTEGER NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    CONSTRAINT "service_log_materials_pkey" PRIMARY KEY ("service_log_id", "material_id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."service_log_photos" (
+    "id" SERIAL NOT NULL,
+    "service_log_id" INTEGER NOT NULL,
+    "url" TEXT NOT NULL,
+    CONSTRAINT "service_log_photos_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."service_log_materials" ADD CONSTRAINT "service_log_materials_service_log_id_fkey" FOREIGN KEY ("service_log_id") REFERENCES "public"."service_logs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."service_log_materials" ADD CONSTRAINT "service_log_materials_material_id_fkey" FOREIGN KEY ("material_id") REFERENCES "public"."materials"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "public"."service_log_photos" ADD CONSTRAINT "service_log_photos_service_log_id_fkey" FOREIGN KEY ("service_log_id") REFERENCES "public"."service_logs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/_/apps/web/prisma/migrations/migration_lock.toml
+++ b/_/apps/web/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"


### PR DESCRIPTION
## Summary
- add SQL migration creating materials, service_log_materials, and service_log_photos tables

## Testing
- `bun db:setup` *(fails: Can't reach database server at ep-soft-violet-a168edqt-pooler.ap-southeast-1.aws.neon.tech:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a81afe8a44832aa90d1a4c9ab0d953