### PR TITLE
refactor: use $extends for prisma caching

### DIFF
--- a/_/apps/web/src/app/api/utils/prisma.js
+++ b/_/apps/web/src/app/api/utils/prisma.js
@@ -18,37 +18,30 @@ if (url) {
   });
   try {
     await redis.ping();
-    const cacheTime = 300;
-    prisma = prisma.$extends({
-      query: {
-        $allModels: {
-          async findMany({ model, args, query }) {
-            const key = `${model}:findMany:${JSON.stringify(args)}`;
-            const cached = await redis.get(key);
-            if (cached) return JSON.parse(cached);
-            const result = await query(args);
-            await redis.set(key, JSON.stringify(result), "EX", cacheTime);
-            return result;
-          },
-          async findUnique({ model, args, query }) {
-            const key = `${model}:findUnique:${JSON.stringify(args)}`;
-            const cached = await redis.get(key);
-            if (cached) return JSON.parse(cached);
-            const result = await query(args);
-            await redis.set(key, JSON.stringify(result), "EX", cacheTime);
-            return result;
-          },
-          async findFirst({ model, args, query }) {
-            const key = `${model}:findFirst:${JSON.stringify(args)}`;
-            const cached = await redis.get(key);
-            if (cached) return JSON.parse(cached);
-            const result = await query(args);
-            await redis.set(key, JSON.stringify(result), "EX", cacheTime);
-            return result;
+    const cacheTime = Number(process.env.REDIS_CACHE_TTL ?? 300);
+
+    const createCacheExtension = (redis, ttl) => {
+      const cached = (action) => async ({ model, args, query }) => {
+        const key = `${model}:${action}:${JSON.stringify(args)}`;
+        const cachedValue = await redis.get(key);
+        if (cachedValue) return JSON.parse(cachedValue);
+        const result = await query(args);
+        await redis.set(key, JSON.stringify(result), "EX", ttl);
+        return result;
+      };
+
+      return {
+        query: {
+          $allModels: {
+            findMany: cached("findMany"),
+            findUnique: cached("findUnique"),
+            findFirst: cached("findFirst"),
           },
         },
-      },
-    });
+      };
+    };
+
+    prisma = prisma.$extends(createCacheExtension(redis, cacheTime));
   } catch (err) {
     console.warn("Unable to connect to Redis; Redis cache disabled", err);
     redis.disconnect();


### PR DESCRIPTION
## Summary
- refactor prisma utility to remove middleware and implement Redis caching via `$extends`

## Testing
- `env DATABASE_URL=postgresql://root:root@localhost:5432/postgres REDIS_URL=redis://127.0.0.1:6379 /root/.nvm/versions/node/v22.18.0/bin/node prisma-test.mjs`
- `redis-cli keys '*'`


------
https://chatgpt.com/codex/tasks/task_e_68a81ae2bd58832ab801ae870fc30931