### PR TITLE
Use react-router navigation for sign in

### DIFF
--- a/_/apps/web/src/app/account/signin/page.jsx
+++ b/_/apps/web/src/app/account/signin/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import useAuth from "@/utils/useAuth";
 import { Eye, EyeOff, Wrench } from "lucide-react";
 
@@ -14,6 +15,8 @@ export default function SignInPage() {
   const [debugInfo, setDebugInfo] = useState("");
 
   const { signInWithCredentials, signInWithGoogle } = useAuth();
+  const navigate = useNavigate();
+  const callbackUrl = "/";
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -31,24 +34,27 @@ export default function SignInPage() {
       console.log("Attempting to sign in with:", email);
       setDebugInfo("Trying main authentication...");
 
-      await signInWithCredentials({
+      const result = await signInWithCredentials({
         email,
         password,
-        callbackUrl: "/",
-        redirect: true,
+        callbackUrl,
+        redirect: false,
       });
 
-      // If we get here, it means auth was successful but didn't redirect
-      setDebugInfo("Main auth successful! Redirecting...");
-      setTimeout(() => {
-        window.location.replace("/");
-      }, 1000);
+      if (!result.error) {
+        setDebugInfo("Main auth successful! Redirecting...");
+        navigate(result.url ?? callbackUrl ?? "/");
+        return;
+      }
+
+      setDebugInfo("Main auth failed, trying fallback...");
     } catch (err) {
       console.error("Main sign in error:", err);
       setDebugInfo("Main auth failed, trying fallback...");
+    }
 
-      // Try fallback method for all errors
-      try {
+    // Try fallback method for all errors
+    try {
         console.log("Trying fallback authentication method...");
 
         const response = await fetch("/api/auth/simple-signin", {
@@ -68,10 +74,7 @@ export default function SignInPage() {
 
         if (data.success) {
           setDebugInfo("Fallback auth successful! Redirecting...");
-          // Small delay to show success message
-          setTimeout(() => {
-            window.location.href = "/";
-          }, 500);
+          navigate("/");
           return;
         } else {
           console.error("Fallback failed:", data);
@@ -90,7 +93,6 @@ export default function SignInPage() {
       }
 
       setLoading(false);
-    }
   };
 
   const handleGoogleSignIn = async () => {


### PR DESCRIPTION
## Summary
- handle credential sign-in without redirect and navigate via useNavigate
- streamline fallback login flow and remove window based redirects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac108407ec832a9370fc16805a81a9