### PR TITLE
feat(mobile): mark auth store ready after token update

### DIFF
--- a/_/apps/mobile/src/utils/auth/store.js
+++ b/_/apps/mobile/src/utils/auth/store.js
@@ -15,7 +15,7 @@ export const useAuthStore = create((set) => ({
     } else {
       SecureStore.deleteItemAsync(authKey);
     }
-    set({ auth });
+    set({ auth, isReady: true });
   },
 }));
 


### PR DESCRIPTION
## Summary
- ensure mobile auth store sets auth and readiness together

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ac1541abc8832aa2c2a2266d827edf