### PR TITLE
Initialize auth token retrieval on hook mount

### DIFF
--- a/_/apps/mobile/src/utils/auth/useAuth.js
+++ b/_/apps/mobile/src/utils/auth/useAuth.js
@@ -1,8 +1,5 @@
-import { router } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
-import { useCallback, useEffect, useMemo } from 'react';
-import { create } from 'zustand';
-import { Modal, View } from 'react-native';
+import { useCallback, useEffect } from 'react';
 import { useAuthModal, useAuthStore, authKey } from './store';
 
 
@@ -14,7 +11,7 @@ import { useAuthModal, useAuthStore, authKey } from './store';
  */
 export const useAuth = () => {
   const { isReady, auth, setAuth } = useAuthStore();
-  const { isOpen, close, open } = useAuthModal();
+  const { close, open } = useAuthModal();
 
   const initiate = useCallback(() => {
     SecureStore.getItemAsync(authKey).then((auth) => {
@@ -25,7 +22,9 @@ export const useAuth = () => {
     });
   }, []);
 
-  useEffect(() => {}, []);
+  useEffect(() => {
+    initiate();
+  }, [initiate]);
 
   const signIn = useCallback(() => {
     open({ mode: 'signin' });
@@ -64,5 +63,4 @@ export const useRequireAuth = (options) => {
     }
   }, [isAuthenticated, open, options?.mode, isReady]);
 };
-
 export default useAuth;


### PR DESCRIPTION
## Summary
- call `initiate` inside `useEffect` so stored auth token is loaded on first use
- drop unused imports and variables from auth hook

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac34d1045c832aa5250ec518ef6e9f